### PR TITLE
Fix: 게시글 검색시, query string validate 오류 수정

### DIFF
--- a/src/article/dto/find-all-article.dto.ts
+++ b/src/article/dto/find-all-article.dto.ts
@@ -1,9 +1,8 @@
-import { IsInt, IsOptional, Min } from 'class-validator';
+import { IsNumberString, IsOptional } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class FindAllArticleDto {
-  @IsInt()
-  @Min(0)
+  @IsNumberString()
   @IsOptional()
   @ApiPropertyOptional({ example: 1 })
   readonly categoryId?: number;


### PR DESCRIPTION
## 바뀐점
- 기존에 type을 Int 로 검사하던걸
- numberstring 으로 변경

## 바꾼이유
- querystring은 문자열이라서, int로 검사가 불가능함

## 설명
