### PR TITLE
Feat: soft delete 추가

### DIFF
--- a/src/article/article.service.ts
+++ b/src/article/article.service.ts
@@ -50,7 +50,7 @@ export class ArticleService {
   }
 
   async remove(id: number, writerId: number): Promise<void> {
-    const result = await this.articleRepository.delete({
+    const result = await this.articleRepository.softDelete({
       id,
       writerId,
     });

--- a/src/article/entities/article.entity.ts
+++ b/src/article/entities/article.entity.ts
@@ -8,6 +8,7 @@ import {
   OneToMany,
   JoinColumn,
   Index,
+  DeleteDateColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { User } from '@user/entities/user.entity';
@@ -59,16 +60,16 @@ export class Article {
   writer?: User;
 
   @ApiProperty()
-  @Column({ nullable: true })
-  deletedAt?: Date;
-
-  @ApiProperty()
   @CreateDateColumn()
   createdAt!: Date;
 
   @ApiProperty()
   @UpdateDateColumn()
   updatedAt!: Date;
+
+  @ApiProperty()
+  @DeleteDateColumn()
+  deletedAt?: Date;
 
   @OneToMany(() => Comment, (comment) => comment.article, {
     createForeignKeyConstraints: false,

--- a/src/article/repositories/article.repository.ts
+++ b/src/article/repositories/article.repository.ts
@@ -26,7 +26,7 @@ export class ArticleRepository extends Repository<Article> {
 
   async isExistById(id: number): Promise<boolean> {
     const exist_query = await this.query(`SELECT EXISTS
-		(SELECT * FROM article WHERE id=${id} deleted_at IS NULL)`);
+		(SELECT * FROM article WHERE id=${id} AND deleted_at IS NULL)`);
     const is_exist = Object.values(exist_query[0])[0];
     return is_exist == 1 ? true : false;
   }

--- a/src/article/repositories/article.repository.ts
+++ b/src/article/repositories/article.repository.ts
@@ -26,7 +26,7 @@ export class ArticleRepository extends Repository<Article> {
 
   async isExistById(id: number): Promise<boolean> {
     const exist_query = await this.query(`SELECT EXISTS
-		(SELECT * FROM article WHERE id=${id})`);
+		(SELECT * FROM article WHERE id=${id} deleted_at IS NULL)`);
     const is_exist = Object.values(exist_query[0])[0];
     return is_exist == 1 ? true : false;
   }

--- a/src/category/category.service.ts
+++ b/src/category/category.service.ts
@@ -27,7 +27,7 @@ export class CategoryService {
   }
 
   async remove(id: number): Promise<void> {
-    const result = await this.categoryRepository.delete({ id });
+    const result = await this.categoryRepository.softDelete({ id });
 
     if (result.affected === 0) {
       throw new NotFoundException(`Can't find Category with id ${id}`);

--- a/src/category/entities/category.entity.ts
+++ b/src/category/entities/category.entity.ts
@@ -7,6 +7,7 @@ import {
   OneToMany,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
 } from 'typeorm';
 
 @Entity('category')
@@ -26,6 +27,10 @@ export class Category {
   @ApiProperty()
   @UpdateDateColumn()
   updatedAt!: Date;
+
+  @ApiProperty()
+  @DeleteDateColumn()
+  deletedAt?: Date;
 
   @OneToMany(() => Article, (article) => article.category, {
     createForeignKeyConstraints: false,

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -50,7 +50,7 @@ export class CommentService {
   }
 
   async remove(id: number, writerId: number): Promise<void> {
-    const result = await this.commentRepository.delete({
+    const result = await this.commentRepository.softDelete({
       id,
       writerId,
     });

--- a/src/comment/entities/comment.entity.ts
+++ b/src/comment/entities/comment.entity.ts
@@ -10,6 +10,7 @@ import {
   ManyToOne,
   JoinColumn,
   Index,
+  DeleteDateColumn,
 } from 'typeorm';
 
 @Entity('comment')
@@ -49,14 +50,14 @@ export class Comment {
   writer?: User;
 
   @ApiProperty()
-  @Column({ nullable: true })
-  deletedAt?: Date;
-
-  @ApiProperty()
   @CreateDateColumn()
   createdAt!: Date;
 
   @ApiProperty()
   @UpdateDateColumn()
   updatedAt!: Date;
+
+  @ApiProperty()
+  @DeleteDateColumn()
+  deletedAt?: Date;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -10,6 +10,7 @@ import {
   UpdateDateColumn,
   OneToMany,
   OneToOne,
+  DeleteDateColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Best } from '@root/best/entities/best.entity';
@@ -55,16 +56,16 @@ export class User {
   character!: number;
 
   @ApiProperty()
-  @Column({ nullable: true })
-  deletedAt?: Date;
-
-  @ApiProperty()
   @CreateDateColumn()
   createdAt!: Date;
 
   @ApiProperty()
   @UpdateDateColumn()
   updatedAt!: Date;
+
+  @ApiProperty()
+  @DeleteDateColumn()
+  deletedAt?: Date;
 
   @OneToMany(() => Article, (article) => article.writer, {
     createForeignKeyConstraints: false,

--- a/src/user/repositories/user.repository.ts
+++ b/src/user/repositories/user.repository.ts
@@ -6,7 +6,7 @@ import { User } from '@user/entities/user.entity';
 export class UserRepository extends Repository<User> {
   async isExistById(id: number): Promise<boolean> {
     const exist_query = await this.query(`SELECT EXISTS
-		(SELECT * FROM user WHERE id=${id})`);
+		(SELECT * FROM user WHERE id=${id} AND deleted_at IS NULL)`);
     const is_exist = Object.values(exist_query[0])[0];
     return is_exist == 1 ? true : false;
   }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -50,6 +50,6 @@ export class UserService {
   }
 
   async remove(id: number): Promise<void> {
-    await this.userRepository.delete({ id });
+    await this.userRepository.softDelete({ id });
   }
 }


### PR DESCRIPTION
## 바뀐점
* 게시물, 댓글, 유저 SoftDelete 추가
* 카테고리에도 SoftDelete 를 추가하였습니다.

## 바꾼이유
* @DeletedDateColumn 을 사용하면,
* typeorm 이 find할떄 자동으로 deleted_at의 여부에 따라서 걸러준다고 합니다.
* 심지어 createQueryBuilder에서 getOne 할떄도, 적용되는거 확인했습니다.
* 대신, raw query로 구현되어있는 부분은 query를 수정하였습니다.

## 설명
[참고](https://wanago.io/2021/10/25/api-nestjs-soft-deletes-postgresql-typeorm)