### PR TITLE
Fix/지워진 게시글의 댓글에 접근가능한 오류 수정

### DIFF
--- a/src/article/article.service.ts
+++ b/src/article/article.service.ts
@@ -29,6 +29,10 @@ export class ArticleService {
     return this.articleRepository.findAll(options);
   }
 
+  existOrFail(id: number): Promise<void> {
+    return this.articleRepository.existOrFail(id);
+  }
+
   getOne(id: number): Promise<Article> {
     return this.articleRepository.findOneOrFail(id);
   }

--- a/src/article/repositories/article.repository.ts
+++ b/src/article/repositories/article.repository.ts
@@ -30,7 +30,7 @@ export class ArticleRepository extends Repository<Article> {
     const exist_query = await this.query(`SELECT EXISTS
 		(SELECT * FROM article WHERE id=${id} AND deleted_at IS NULL)`);
     const is_exist = Object.values(exist_query[0])[0];
-    if (!is_exist) {
+    if (is_exist === '0') {
       throw new NotFoundException(`Can't find Article with id ${id}`);
     }
   }

--- a/src/article/repositories/article.repository.ts
+++ b/src/article/repositories/article.repository.ts
@@ -2,6 +2,7 @@ import { EntityRepository, Repository } from 'typeorm';
 
 import { Article } from '@article/entities/article.entity';
 import { FindAllArticleDto } from '@article/dto/find-all-article.dto';
+import { NotFoundException } from '@nestjs/common';
 
 @EntityRepository(Article)
 export class ArticleRepository extends Repository<Article> {
@@ -23,5 +24,14 @@ export class ArticleRepository extends Repository<Article> {
       .leftJoinAndSelect('article.reactionArticle', 'reactionArticle')
       .andWhere('article.id = :id', { id })
       .getOneOrFail();
+  }
+
+  async existOrFail(id: number): Promise<void> {
+    const exist_query = await this.query(`SELECT EXISTS
+		(SELECT * FROM article WHERE id=${id} AND deleted_at IS NULL)`);
+    const is_exist = Object.values(exist_query[0])[0];
+    if (!is_exist) {
+      throw new NotFoundException(`Can't find Article with id ${id}`);
+    }
   }
 }

--- a/src/category/repositories/category.repository.ts
+++ b/src/category/repositories/category.repository.ts
@@ -9,7 +9,7 @@ export class CategoryRepository extends Repository<Category> {
     const exist_query = await this.query(`SELECT EXISTS
 		(SELECT * FROM category WHERE id=${id} AND deleted_at IS NULL)`);
     const is_exist = Object.values(exist_query[0])[0];
-    if (!is_exist) {
+    if (is_exist === '0') {
       throw new NotFoundException(`Can't find Category with id ${id}`);
     }
   }

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -38,7 +38,8 @@ export class CommentService {
     return comment;
   }
 
-  findAllByArticleId(articleId: number): Promise<Comment[]> {
+  async findAllByArticleId(articleId: number): Promise<Comment[]> {
+    await this.articleService.existOrFail(articleId);
     return this.commentRepository.findAllByArticleId(articleId);
   }
 

--- a/src/comment/repositories/comment.repository.ts
+++ b/src/comment/repositories/comment.repository.ts
@@ -16,7 +16,7 @@ export class CommentRepository extends Repository<Comment> {
     const exist_query = await this.query(`SELECT EXISTS
       (SELECT * FROM comment WHERE id=${id} AND deleted_at IS NULL)`);
     const is_exist = Object.values(exist_query[0])[0];
-    if (!is_exist) {
+    if (is_exist === '0') {
       throw new NotFoundException(`Can't find Comments with id ${id}`);
     }
   }

--- a/src/user/repositories/user.repository.ts
+++ b/src/user/repositories/user.repository.ts
@@ -8,6 +8,6 @@ export class UserRepository extends Repository<User> {
     const exist_query = await this.query(`SELECT EXISTS
 		(SELECT * FROM user WHERE id=${id} AND deleted_at IS NULL)`);
     const is_exist = Object.values(exist_query[0])[0];
-    return is_exist == 1 ? true : false;
+    return is_exist === '1' ? true : false;
   }
 }


### PR DESCRIPTION
## 바뀐점
* 댓글 가져올떄, 게시글이 지워져있는지 한번 확인하도록 수정하였습니다.
* existOrFail구현시, 문자열처리를 다시 수정하였습니다.

## 바꾼이유
* 게시글의 존재 유무를 확인해야 댓글을 확실히 안가져올수있습니다.
