### PR TITLE
Feat: 댓글 생성 api 결과값 변경

### DIFF
--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -15,7 +15,9 @@ import {
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { GetUser } from '@root/auth/auth.decorator';
+import { User } from '@root/user/entities/user.entity';
 import { CommentService } from './comment.service';
+import { CreateCommentResultDto } from './dto/create-comment-result.dto';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 import { Comment } from './entities/comment.entity';
@@ -30,11 +32,16 @@ export class CommentController {
   @Post()
   @ApiOperation({ summary: '댓글 생성' })
   @ApiOkResponse({ description: '생성된 댓글', type: Comment })
-  create(
-    @GetUser('id') writerId: number,
+  async create(
+    @GetUser() writer: User,
     @Body() createCommentDto: CreateCommentDto,
-  ): Promise<Comment> {
-    return this.commentService.create(writerId, createCommentDto);
+  ): Promise<CreateCommentResultDto> {
+    const comment = await this.commentService.create(
+      writer.id,
+      createCommentDto,
+    );
+
+    return { ...comment, nickname: writer.nickname };
   }
 
   @Put(':id')

--- a/src/comment/dto/create-comment-result.dto.ts
+++ b/src/comment/dto/create-comment-result.dto.ts
@@ -1,0 +1,9 @@
+export class CreateCommentResultDto {
+  id: number;
+  content: string;
+  likeCount: number;
+  articleId: number;
+  writerId: number;
+  createdAt: Date;
+  nickname: string;
+}


### PR DESCRIPTION
## 바뀐점
- 댓글 생성한 사람의 닉네임 추가

## 바꾼이유
- 프론트에서 댓글 생성 직후 사용자의 닉네임이 필요하여 추가됨
