### PR TITLE
Feature/user e2e

### DIFF
--- a/run_test_db.sh
+++ b/run_test_db.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 docker run -d --rm --name ft_world-mysql-test \
+--platform linux/x86_64 \
 -e MYSQL_DATABASE=ft_world \
 -e MYSQL_USER=ft_world \
 -e MYSQL_PASSWORD=ft_world \

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -16,6 +16,7 @@
     "^@comment/(.*)$": "<rootDir>/../src/comment/$1",
     "^@authenticate/(.*)$": "<rootDir>/../src/authenticate/$1",
     "^@notification/(.*)$": "<rootDir>/../src/notification/$1",
-    "^@database/(.*)$": "<rootDir>/../src/database/$1"
+    "^@database/(.*)$": "<rootDir>/../src/database/$1",
+    "^@ft-auth/(.*)$": "<rootDir>/../src/ft-auth/$1"
   }
 }

--- a/test/test.base.module.ts
+++ b/test/test.base.module.ts
@@ -5,6 +5,8 @@ import * as path from 'path';
 import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from '@auth/jwt-auth.guard';
+import { getEnvPath } from '@root/utils';
+import configEmail from '@root/config/mail.config';
 
 @Module({
   imports: [
@@ -20,7 +22,12 @@ import { JwtAuthGuard } from '@auth/jwt-auth.guard';
       synchronize: true,
       logging: true,
     }),
-    ConfigModule,
+    ConfigModule.forRoot({
+      envFilePath: getEnvPath(),
+      isGlobal: true,
+      cache: true,
+      load: [configEmail],
+    }),
   ],
   providers: [
     {

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -12,6 +12,7 @@ import { User, UserRole } from '@user/entities/user.entity';
 import { JWTPayload } from '@auth/interfaces/jwt-payload.interface';
 import { AuthService } from '@auth/auth.service';
 import { TestBaseModule } from './test.base.module';
+import { UpdateUserDto } from '@user/dto/update-user.dto';
 
 describe('UserController (e2e)', () => {
   let app: INestApplication;
@@ -89,6 +90,24 @@ describe('UserController (e2e)', () => {
     expect(response.body.id).toEqual(2);
   });
 
+  it('유저 프로필 변경', async () => {
+    const updateData = {
+      nickname: 'rockpell',
+      character: 2,
+    } as UpdateUserDto;
+
+    const response = await request(app)
+      .put('/users')
+      .send(updateData)
+      .set('Cookie', `access_token=${JWT}`);
+
+    expect(response.status).toEqual(200);
+
+    const updatedUser = await userRepository.findOne(1);
+    expect(updatedUser.nickname).toEqual('rockpell');
+    expect(updatedUser.character).toEqual(2);
+  });
+
   it('유저 삭제하기', async () => {
     const response = await request(app)
       .delete('/users')
@@ -97,6 +116,7 @@ describe('UserController (e2e)', () => {
     expect(response.status).toEqual(200);
 
     const deletedUser = await userRepository.findOne(1, { withDeleted: true });
+
     expect(deletedUser.deletedAt).toBeTruthy();
   });
 });

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -21,7 +21,7 @@ describe('UserController (e2e)', () => {
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [TestBaseModule, AuthModule, UserModule],
+      imports: [TestBaseModule, UserModule, AuthModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();
@@ -74,7 +74,7 @@ describe('UserController (e2e)', () => {
 
   it('내 정보 가져오기', async () => {
     const response = await request(app)
-      .get('/users')
+      .get('/users/me')
       .set('Cookie', `access_token=${JWT}`);
 
     expect(response.status).toEqual(200);
@@ -96,7 +96,7 @@ describe('UserController (e2e)', () => {
 
     expect(response.status).toEqual(200);
 
-    const deletedUser = await userRepository.findOne(1);
+    const deletedUser = await userRepository.findOne(1, { withDeleted: true });
     expect(deletedUser.deletedAt).toBeTruthy();
   });
 });


### PR DESCRIPTION
## 바뀐점
- user e2e 테스트 안돌아가던거 수정
- 지금 구현된 user api e2e 테스트 추가
- test db docker를 생성하는 쉘 스크립트에 플랫폼 지정하는 옵션 추가

## 설명
- config module을 사용할 때 env 파일을 제대로 안가져오고 있어서 생긴 에러였음
- 유저가 작성한 글, 댓글 목록 가져오기 와 좋아요 누른 글에 대한 test도 추가 완료
- m1 맥북에서는 플랫폼 지정이 안된 mysql docker가 안돌아가서 추가