### PR TITLE
Refactor: 42 checkin service move from apps

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,66 +1,14 @@
-import { CACHE_MANAGER, Controller, Get, Inject } from '@nestjs/common';
-import {
-  ApiOkResponse,
-  ApiOperation,
-  ApiProperty,
-  ApiTags,
-} from '@nestjs/swagger';
+import { Controller, Get } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Public } from '@auth/auth.decorator';
-import axios from 'axios';
-import { Cache } from 'cache-manager';
-import { HOUR } from './utils';
-import { AppService, GetFtCheckinDto } from './app.service';
-
-const FT_CHECKIN_API = 'FT_CHECKIN_API';
-const FT_CHECKIN_CACHE_TTL = 100;
-
-const MAX_CHECKIN_API = 'MAX_CHECKIN_API';
-const MAX_CHECKIN_CACHE_TTL = HOUR * 6;
-
-class FtCheckData {
-  @ApiProperty()
-  now: GetFtCheckinDto;
-  @ApiProperty()
-  max: GetFtCheckinDto;
-}
 @ApiTags('Hello')
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
-
   @Get()
   @Public()
   @ApiOperation({ summary: 'Hello world!' })
   @ApiOkResponse({ description: 'Hello world!' })
   getHello(): string {
     return 'Hello World!';
-  }
-
-  @Get('ft-checkin')
-  @Public()
-  @ApiOperation({ summary: '42checkin api' })
-  @ApiOkResponse({
-    description: '42체크인 user using api 결과',
-    type: FtCheckData,
-  })
-  async getFtCheckin(): Promise<FtCheckData> {
-    const checkinData = await this.appService.fetchData(
-      FT_CHECKIN_API,
-      FT_CHECKIN_CACHE_TTL,
-      'https://api.checkin.42seoul.io/user/using',
-    );
-
-    const checkinInfo = await this.appService.fetchData(
-      MAX_CHECKIN_API,
-      MAX_CHECKIN_CACHE_TTL,
-      'https://api.checkin.42seoul.io/config',
-    );
-
-    const data = {
-      now: checkinData,
-      max: checkinInfo,
-    };
-
-    return data;
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,7 +26,7 @@ import { DatabaseModule } from './database/database.module';
 import { getEnvPath } from './utils';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
 import { ormconfig } from './database/ormconfig';
-import { AppService } from './app.service';
+import { FtCheckinModule } from './ft-checkin/ft-checkin.module';
 
 @Module({
   imports: [
@@ -81,6 +81,7 @@ import { AppService } from './app.service';
     AuthModule,
     BestModule,
     ReactionModule,
+    FtCheckinModule,
   ],
   controllers: [AppController],
   providers: [
@@ -88,7 +89,6 @@ import { AppService } from './app.service';
       provide: APP_GUARD,
       useClass: JwtAuthGuard,
     },
-    AppService,
   ],
 })
 export class AppModule {}

--- a/src/ft-checkin/ft-checkin.controller.spec.ts
+++ b/src/ft-checkin/ft-checkin.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FtCheckinController } from './ft-checkin.controller';
+import { FtCheckinService } from './ft-checkin.service';
+
+describe('FtCheckinController', () => {
+  let controller: FtCheckinController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FtCheckinController],
+      providers: [FtCheckinService],
+    }).compile();
+
+    controller = module.get<FtCheckinController>(FtCheckinController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/ft-checkin/ft-checkin.controller.ts
+++ b/src/ft-checkin/ft-checkin.controller.ts
@@ -1,0 +1,63 @@
+import { FtCheckinService, GetFtCheckinDto } from './ft-checkin.service';
+import { Controller, Get } from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiProperty,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Public } from '@auth/auth.decorator';
+import { HOUR } from '@root/utils';
+
+const FT_CHECKIN_API = 'FT_CHECKIN_API';
+const FT_CHECKIN_CACHE_TTL = 100;
+const FT_CHECKIN_END_POINT = 'https://api.checkin.42seoul.io/user/using';
+
+const MAX_CHECKIN_API = 'MAX_CHECKIN_API';
+const MAX_CHECKIN_CACHE_TTL = HOUR * 6;
+const MAX_CHECKIN_END_POINT = 'https://api.checkin.42seoul.io/config';
+
+class FtCheckData {
+  @ApiProperty()
+  now: GetFtCheckinDto;
+  @ApiProperty()
+  max: GetFtCheckinDto;
+}
+
+@ApiTags('ft-checkin')
+@Controller('ft-checkin')
+export class FtCheckinController {
+  constructor(private readonly ftCheckinService: FtCheckinService) {}
+
+  @Get()
+  @Public()
+  @ApiOperation({ summary: '42checkin api' })
+  @ApiOkResponse({
+    description: '42체크인 user using api 결과',
+    type: FtCheckData,
+  })
+  async getFtCheckin(): Promise<FtCheckData> {
+    try {
+      const checkinData = await this.ftCheckinService.fetchData(
+        FT_CHECKIN_API,
+        FT_CHECKIN_CACHE_TTL,
+        FT_CHECKIN_END_POINT,
+      );
+
+      const checkinInfo = await this.ftCheckinService.fetchData(
+        MAX_CHECKIN_API,
+        MAX_CHECKIN_CACHE_TTL,
+        MAX_CHECKIN_END_POINT,
+      );
+
+      const data = {
+        now: checkinData,
+        max: checkinInfo,
+      };
+
+      return data;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+}

--- a/src/ft-checkin/ft-checkin.controller.ts
+++ b/src/ft-checkin/ft-checkin.controller.ts
@@ -1,5 +1,5 @@
 import { FtCheckinService, GetFtCheckinDto } from './ft-checkin.service';
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, NotFoundException } from '@nestjs/common';
 import {
   ApiOkResponse,
   ApiOperation,
@@ -57,7 +57,7 @@ export class FtCheckinController {
 
       return data;
     } catch (e) {
-      console.error(e);
+      throw new NotFoundException('데이터를 받아올 수 없습니다');
     }
   }
 }

--- a/src/ft-checkin/ft-checkin.module.ts
+++ b/src/ft-checkin/ft-checkin.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { FtCheckinService } from './ft-checkin.service';
+import { FtCheckinController } from './ft-checkin.controller';
+
+@Module({
+  controllers: [FtCheckinController],
+  providers: [FtCheckinService],
+})
+export class FtCheckinModule {}

--- a/src/ft-checkin/ft-checkin.service.spec.ts
+++ b/src/ft-checkin/ft-checkin.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FtCheckinService } from './ft-checkin.service';
+
+describe('FtCheckinService', () => {
+  let service: FtCheckinService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FtCheckinService],
+    }).compile();
+
+    service = module.get<FtCheckinService>(FtCheckinService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/ft-checkin/ft-checkin.service.ts
+++ b/src/ft-checkin/ft-checkin.service.ts
@@ -5,9 +5,11 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { Cache } from 'cache-manager';
-
 import axios from 'axios';
 import { ApiProperty } from '@nestjs/swagger';
+
+const GAEPO = 'gaepo';
+const SECHO = 'secho';
 
 export class GetFtCheckinDto {
   @ApiProperty({ example: 42 })
@@ -18,7 +20,7 @@ export class GetFtCheckinDto {
 }
 
 @Injectable()
-export class AppService {
+export class FtCheckinService {
   constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
 
   async fetchData(
@@ -34,8 +36,8 @@ export class AppService {
       try {
         const { data } = await axios.get(endpoint);
         const realData = {
-          seocho: data['seocho'],
-          gaepo: data['gaepo'],
+          seocho: data[SECHO],
+          gaepo: data[GAEPO],
         };
 
         await this.cacheManager.set(cacheKey, realData, {


### PR DESCRIPTION
## 바뀐점
- apps에 있던 42 checkin service를 리팩토링 했습니다.

## 바꾼이유
- 도저히 참을 수 없었기 때문 ... 🤣 

## 설명
- 상수를 따로 뺐으나, 이 기능에서만 사용될 것 같아 한 파일 내에서 관리합니다.
- apps에 있던 것을 새로 모듈을 파서 관리하였습니다.