### PR TITLE
Fix: 댓글 생성 결과 dto 수정

### DIFF
--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -41,7 +41,7 @@ export class CommentController {
       createCommentDto,
     );
 
-    return { ...comment, nickname: writer.nickname };
+    return { ...comment, writer: { nickname: writer.nickname } };
   }
 
   @Put(':id')

--- a/src/comment/dto/create-comment-result.dto.ts
+++ b/src/comment/dto/create-comment-result.dto.ts
@@ -5,5 +5,7 @@ export class CreateCommentResultDto {
   articleId: number;
   writerId: number;
   createdAt: Date;
-  nickname: string;
+  writer: {
+    nickname: string;
+  };
 }


### PR DESCRIPTION
## 바뀐점
- 지금당장은 join한 결과를 응답하고 있지 않기 때문에
- 임시방편으로 댓글 생성 결과 dto에 writer 를 넣는것으로 수정하였습니다

## 바꾼이유
- 프론트에서 writer가 join된 결과에서 nickname을 찾아 출력하고있어서 수정했습니다.

## 설명
- 사실 프론트에서도 본인 닉네임을 가지고있기 때문에 백엔드에서 안보내줘도 되지만,
- 생성dto 와 검색 결과 dto 를 일관성있게 하는게 좋을지는 고민해봐야할거같습니다.
- 추후에 프론트와 논의가 필요할거같습니다.
