### PR TITLE
Fix: typeorm 에 timezone 설정

### DIFF
--- a/src/database/ormconfig.ts
+++ b/src/database/ormconfig.ts
@@ -17,6 +17,7 @@ export const ormconfig = (): IOrmconfig => ({
 
     synchronize: false,
     migrationsRun: true,
+    timezone: 'Z',
     logging: process.env.NODE_ENV !== 'prod',
 
     migrations: [__dirname + '/migrations/**/*{.ts,.js}'],


### PR DESCRIPTION
## 바뀐점
- typeorm에 timezone 을 추가했습니다.

## 바꾼이유
- db에는 값이 잘 들어가지만,
- typeorm 에서 다시 값을 바꿔버리고 있어서 시간이 달랐습니다.

## 설명
https://soo-sin.tistory.com/m/24