### PR TITLE
typeorm log, dev 환경일때만 되도록 수정

### DIFF
--- a/src/database/ormconfig.ts
+++ b/src/database/ormconfig.ts
@@ -17,7 +17,7 @@ export const ormconfig = (): IOrmconfig => ({
 
     synchronize: false,
     migrationsRun: true,
-    logging: process.env.NODE_ENV !== 'prod',
+    logging: process.env.NODE_ENV === 'dev',
 
     migrations: [__dirname + '/migrations/**/*{.ts,.js}'],
     cli: {


### PR DESCRIPTION
## 바뀐점
- typeorm log, dev 환경일때만 되도록 수정

## 바꾼이유
- alpha, prod 같은 배포 환경에서는 쿼리 로그보다는 다른 로그를 더 많이 봐야하기 때문에 typeorm log가 안찍히도록 config 수정

## 설명
- ormconfig의 loggin을 true로 하면 typeorm이 생성하여 실행하는 쿼리를 로깅 할 수 있다.