### PR TITLE
500 error 글로벌 필터 적용, 에러 발생시 슬랙으로 메시지 발송

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Public } from '@auth/auth.decorator';
+
 @ApiTags('Hello')
 @Controller()
 export class AppController {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,20 +1,12 @@
 import {
-  Body,
   Controller,
   Delete,
   Get,
-  Post,
   Res,
+  UseFilters,
   UseGuards,
 } from '@nestjs/common';
 import { Response } from 'express';
-import { UserService } from '@user/user.service';
-import { AuthService } from './auth.service';
-import { GithubAuthGuard } from './github-auth.guard';
-import { JWTPayload } from './interfaces/jwt-payload.interface';
-import { GithubProfile } from './interfaces/github-profile.interface';
-import { ACCESS_TOKEN } from './constants/access-token';
-import { GetGithubProfile, Public } from './auth.decorator';
 import {
   ApiCookieAuth,
   ApiOkResponse,
@@ -22,6 +14,15 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { AllExceptionsFilter } from '@root/filters/all-exception.filter';
+
+import { UserService } from '@user/user.service';
+import { AuthService } from './auth.service';
+import { GithubAuthGuard } from './github-auth.guard';
+import { JWTPayload } from './interfaces/jwt-payload.interface';
+import { GithubProfile } from './interfaces/github-profile.interface';
+import { ACCESS_TOKEN } from './constants/access-token';
+import { GetGithubProfile, Public } from './auth.decorator';
 import { getCookieOption } from '@root/utils';
 
 @ApiTags('Auth')
@@ -50,6 +51,7 @@ export class AuthController {
   @Get('github/callback')
   @Public()
   @UseGuards(GithubAuthGuard)
+  @UseFilters(AllExceptionsFilter)
   @ApiOperation({
     summary: '깃허브 로그인 콜백',
     description: `

--- a/src/filters/all-exception.filter.ts
+++ b/src/filters/all-exception.filter.ts
@@ -1,39 +1,22 @@
-import {
-  ExceptionFilter,
-  Catch,
-  ArgumentsHost,
-  HttpException,
-  HttpStatus,
-} from '@nestjs/common';
-import { HttpAdapterHost } from '@nestjs/core';
+import { ExceptionFilter, Catch, ArgumentsHost } from '@nestjs/common';
 import { INTERNAL_ERROR_MESSAGE } from '@root/filters/constant';
 import { errorHook } from '@root/utils';
+import { Response } from 'express';
 
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {
-  constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
-
-  catch(
-    exception: { stack: string; message: string },
-    host: ArgumentsHost,
-  ): void {
-    const { httpAdapter } = this.httpAdapterHost;
-
+  catch(exception: { stack: string; message: string }, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
-
-    const httpStatus =
-      exception instanceof HttpException
-        ? exception.getStatus()
-        : HttpStatus.INTERNAL_SERVER_ERROR;
-
-    const responseBody = {
-      statusCode: httpStatus,
-      message: INTERNAL_ERROR_MESSAGE,
-    };
+    const response = ctx.getResponse<Response>();
 
     console.error(exception);
     errorHook('Unknown Error', exception.message);
 
-    httpAdapter.reply(ctx.getResponse(), responseBody, httpStatus);
+    return response.status(500).json({
+      message: {
+        statusCode: 500,
+        message: INTERNAL_ERROR_MESSAGE,
+      },
+    });
   }
 }

--- a/src/filters/all-exception.filter.ts
+++ b/src/filters/all-exception.filter.ts
@@ -1,0 +1,39 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { INTERNAL_ERROR_MESSAGE } from '@root/filters/constant';
+import { errorHook } from '@root/utils';
+
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+
+  catch(
+    exception: { stack: string; message: string },
+    host: ArgumentsHost,
+  ): void {
+    const { httpAdapter } = this.httpAdapterHost;
+
+    const ctx = host.switchToHttp();
+
+    const httpStatus =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const responseBody = {
+      statusCode: httpStatus,
+      message: INTERNAL_ERROR_MESSAGE,
+    };
+
+    console.error(exception);
+    errorHook('Unknown Error', exception.message);
+
+    httpAdapter.reply(ctx.getResponse(), responseBody, httpStatus);
+  }
+}

--- a/src/filters/constant.ts
+++ b/src/filters/constant.ts
@@ -1,0 +1,1 @@
+export const INTERNAL_ERROR_MESSAGE = 'Something Went Wrong';

--- a/src/filters/internal-server-error-exception.filter.ts
+++ b/src/filters/internal-server-error-exception.filter.ts
@@ -1,0 +1,25 @@
+import {
+  Catch,
+  ExceptionFilter,
+  ArgumentsHost,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { errorHook } from '@root/utils';
+
+@Catch(InternalServerErrorException)
+export class InternalServerErrorExceptionFilter implements ExceptionFilter {
+  public catch(exception: InternalServerErrorException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    errorHook(exception.name, exception.message);
+
+    return response.status(500).json({
+      message: {
+        statusCode: 500,
+        message: 'Something Went Wrong',
+      },
+    });
+  }
+}

--- a/src/filters/internal-server-error-exception.filter.ts
+++ b/src/filters/internal-server-error-exception.filter.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { Response } from 'express';
 import { errorHook } from '@root/utils';
+import { INTERNAL_ERROR_MESSAGE } from '@root/filters/constant';
 
 @Catch(InternalServerErrorException)
 export class InternalServerErrorExceptionFilter implements ExceptionFilter {
@@ -13,12 +14,13 @@ export class InternalServerErrorExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
 
+    console.error(exception);
     errorHook(exception.name, exception.message);
 
     return response.status(500).json({
       message: {
         statusCode: 500,
-        message: 'Something Went Wrong',
+        message: INTERNAL_ERROR_MESSAGE,
       },
     });
   }

--- a/src/filters/typeorm-exception.filter.ts
+++ b/src/filters/typeorm-exception.filter.ts
@@ -3,6 +3,7 @@ import { Response } from 'express';
 import { TypeORMError } from 'typeorm';
 import { EntityNotFoundError } from 'typeorm/error/EntityNotFoundError';
 import { errorHook } from '@root/utils';
+import { INTERNAL_ERROR_MESSAGE } from '@root/filters/constant';
 
 const FIND_DOUBLE_QUOTE = /\"/g;
 
@@ -21,13 +22,13 @@ export class TypeormExceptionFilter implements ExceptionFilter {
       });
     }
 
-    errorHook(exception.name, exception.message);
     console.error(exception);
+    errorHook(exception.name, exception.message);
 
     return response.status(500).json({
       message: {
         statusCode: 500,
-        message: 'Something Went Wrong',
+        message: INTERNAL_ERROR_MESSAGE,
       },
     });
   }

--- a/src/filters/typeorm-exception.filter.ts
+++ b/src/filters/typeorm-exception.filter.ts
@@ -2,7 +2,7 @@ import { Catch, ExceptionFilter, ArgumentsHost } from '@nestjs/common';
 import { Response } from 'express';
 import { TypeORMError } from 'typeorm';
 import { EntityNotFoundError } from 'typeorm/error/EntityNotFoundError';
-import axios from 'axios';
+import { errorHook } from '@root/utils';
 
 const FIND_DOUBLE_QUOTE = /\"/g;
 
@@ -21,15 +21,7 @@ export class TypeormExceptionFilter implements ExceptionFilter {
       });
     }
 
-    const PHASE = process.env.NODE_ENV;
-    const slackMessage = `[${PHASE}] ${exception.name}: ${exception.message}}`;
-
-    try {
-      axios.post(process.env.SLACK_HOOK_URL, { text: slackMessage }).then();
-    } catch (e) {
-      throw e;
-    }
-
+    errorHook(exception.name, exception.message);
     console.error(exception);
 
     return response.status(500).json({

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { AppModule } from './app.module';
 import { ACCESS_TOKEN } from '@auth/constants/access-token';
 import { ValidationPipe } from '@nestjs/common';
 import { TypeormExceptionFilter } from '@root/filters/typeorm-exception.filter';
+import { InternalServerErrorExceptionFilter } from '@root/filters/internal-server-error-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -41,6 +42,7 @@ async function bootstrap() {
     credentials: true,
   });
   app.useGlobalFilters(new TypeormExceptionFilter());
+  app.useGlobalFilters(new InternalServerErrorExceptionFilter());
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true, // decorator(@)가 없는 속성이 들어오면 해당 속성은 제거하고 받아들입니다.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,13 +36,16 @@ export const getCookieOption = (): CookieOptions => {
   return {};
 };
 
-export const errorHook = (exceptionName, exceptionMessage) => {
+export const errorHook = async (
+  exceptionName: string,
+  exceptionMessage: string,
+) => {
   const PHASE = process.env.NODE_ENV;
   const slackMessage = `[${PHASE}] ${exceptionName}: ${exceptionMessage}`;
 
   try {
-    axios.post(process.env.SLACK_HOOK_URL, { text: slackMessage }).then();
+    await axios.post(process.env.SLACK_HOOK_URL, { text: slackMessage });
   } catch (e) {
-    throw e;
+    console.error(e);
   }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { CookieOptions } from 'express';
+import axios from 'axios';
 
 export const MINUTE = 60;
 export const HOUR = 60 * MINUTE;
@@ -33,4 +34,15 @@ export const getCookieOption = (): CookieOptions => {
     return { secure: true, sameSite: 'none' };
   }
   return {};
+};
+
+export const errorHook = (exceptionName, exceptionMessage) => {
+  const PHASE = process.env.NODE_ENV;
+  const slackMessage = `[${PHASE}] ${exceptionName}: ${exceptionMessage}`;
+
+  try {
+    axios.post(process.env.SLACK_HOOK_URL, { text: slackMessage }).then();
+  } catch (e) {
+    throw e;
+  }
 };


### PR DESCRIPTION
## 바뀐점
- 500에러 글로벌 필터 적용
- 해당 필터에서 slack으로 에러메시지 발송하도록 기능 추가
- 모든 에러를 처리하는 필터 추가, github callback api에서는 이 에러필터를 사용

## 바꾼이유
- 기존에 db에러만 잡고 있었기 때문에 500 에러도 처리하고 슬랙으로 메시지 보낼수 있도록 수정
- github callback api에서 발생하는 500 에러 필터로 잡히지 않아 모든 에러를 처리하는 필터를 별도로 사용

close #69 