### PR TITLE
[FIX] 작성자가 글에 접속하면 조회수가 오르지 않도록 수정

### DIFF
--- a/src/article/article.controller.ts
+++ b/src/article/article.controller.ts
@@ -81,8 +81,8 @@ export class ArticleController {
       userId,
       articleId,
     );
-
-    this.articleService.increaseViewCount(article);
+    if (article.writerId !== userId)
+      this.articleService.increaseViewCount(article);
     return { ...article, isLike };
   }
 


### PR DESCRIPTION
## 바뀐점
increaseViewCount가 article.writerId(작성자 id)와 UserId(글을 보고 있는 유저 id)가 다를 경우에만 실행되도록 변경하였습니다.
## 바꾼이유
조회수를 올리기 위해 여러 번 들어가 조회수를 일부러 올리는 작성자(= 나)를 막기 위해 작성자가 아닌 경우에만 조회수가 올라가도록 수정하였습니다.  
## 설명
원래 여기엔 뭘 써야 할까요...? 음... 이걸 고치기 위해 많은 도움을 주신 ycha님 샤라웃하겠습니다 ㅎㅎ