### PR TITLE
Fix: nest 빌드할 때 ejs를 가져가는 option 변경

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -2,7 +2,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "",
   "compilerOptions": {
-    "assets": [{ "include": "**/*.ejs" }],
+    "assets": [{ "include": "views/**/*.ejs" }],
     "watchAssets": true
   }
 }


### PR DESCRIPTION
## 바뀐점
- **은 모든 디렉토리를 검사하기 때문에 빌드 속도가 느려지는 문제가 있었다
- views 디렉토리로 특정하여 기존 빌드 속도로 복구 완료

## 바꾼이유
- 불필요한 디렉토리 탐색을 없애기 위함

## 설명
- ejs를 사용하기 위한 설정때문에 빌드가 느려지는 현상 개선