### PR TITLE
Feat: notification 에 content id 추가

### DIFF
--- a/src/notification/dto/create-notification.dto.ts
+++ b/src/notification/dto/create-notification.dto.ts
@@ -3,5 +3,6 @@ import { NotificationType } from '../entities/notification.entity';
 export class CreateNotificationDto {
   readonly type!: NotificationType;
   readonly content!: string;
+  readonly contentId!: number;
   readonly userId!: number;
 }

--- a/src/notification/entities/notification.entity.ts
+++ b/src/notification/entities/notification.entity.ts
@@ -38,6 +38,10 @@ export class Notification {
   content!: string;
 
   @ApiProperty()
+  @Column({ nullable: false })
+  contentId: number;
+
+  @ApiProperty()
   @Column({ nullable: false, default: false })
   isRead!: boolean;
 

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -17,6 +17,7 @@ export class NotificationService {
     const notification: CreateNotificationDto = {
       type: NotificationType.NEW_COMMENT,
       content: comment.content,
+      contentId: article.id,
       userId: article.writerId,
     };
     return this.notificationRepository.save(notification);


### PR DESCRIPTION
## 바뀐점
- entity column 에 contentId 추가
- 알람 생성시, 게시글 id 를 저장하도록 변경

## 바꾼이유
- 알람을 클릭하면 이동할 게시글 아이디를 저장하고 있어야 해당 게시글로 이동할 수 있음.

## 설명
