### PR TITLE
Fix: 내 좋아요 게시글 응답 타입 변경

### DIFF
--- a/src/reaction/reaction.service.ts
+++ b/src/reaction/reaction.service.ts
@@ -118,7 +118,13 @@ export class ReactionService {
     });
   }
 
-  findAllArticleByUserId(userId: number): Promise<ReactionArticle[]> {
-    return this.reactionArticleRepository.findAllArticleByUserId(userId);
+  findAllMyReactionArticle(
+    userId: number,
+    type: ReactionArticleType = ReactionArticleType.LIKE,
+  ): Promise<ReactionArticle[]> {
+    return this.reactionArticleRepository.findAllMyReactionArticle(
+      userId,
+      type,
+    );
   }
 }

--- a/src/reaction/repositories/reaction-article.repository.ts
+++ b/src/reaction/repositories/reaction-article.repository.ts
@@ -16,11 +16,15 @@ export class ReactionArticleRepository extends Repository<ReactionArticle> {
     return Object.values(existQuery[0])[0] === '1';
   }
 
-  async findAllArticleByUserId(userId: number): Promise<ReactionArticle[]> {
+  async findAllMyReactionArticle(
+    userId: number,
+    type: ReactionArticleType = ReactionArticleType.LIKE,
+  ): Promise<ReactionArticle[]> {
     return this.createQueryBuilder('reactionArticle')
       .leftJoinAndSelect('reactionArticle.article', 'article')
       .leftJoinAndSelect('article.category', 'category')
       .andWhere('reactionArticle.userId = :id', { id: userId })
+      .andWhere('reactionArticle.type = :type', { type })
       .getMany();
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -20,7 +20,10 @@ import { UpdateUserDto } from './dto/update-user.dto';
 import { User } from './entities/user.entity';
 import { NotificationService } from '@root/notification/notification.service';
 import { ReactionService } from '@root/reaction/reaction.service';
-import { ReactionArticle } from '@root/reaction/entities/reaction-article.entity';
+import {
+  ReactionArticle,
+  ReactionArticleType,
+} from '@root/reaction/entities/reaction-article.entity';
 import { ArticleService } from '@article/article.service';
 import { CommentService } from '@comment/comment.service';
 import { Article } from '@article/entities/article.entity';
@@ -85,10 +88,14 @@ export class UserController {
     description: '유저가 좋아요 누른 게시글 목록',
     type: [ReactionArticle],
   })
-  findAllReactionArticle(
+  async findAllReactionArticle(
     @GetUser('id') userId: number,
-  ): Promise<ReactionArticle[]> {
-    return this.reactionService.findAllArticleByUserId(userId);
+  ): Promise<Article[]> {
+    const likeArticles = await this.reactionService.findAllMyReactionArticle(
+      userId,
+      ReactionArticleType.LIKE,
+    );
+    return likeArticles.map((e) => e.article);
   }
 
   @Get('me/articles')


### PR DESCRIPTION
## 바뀐점
- 기존에 ReactionArticle[] 반환에서
- Article[] 반환으로 변경
- 함수이름 findAllMyReactionArticle로 변경
- query시 type도 포함하여 검색

## 바꾼이유
- 내가 좋아요 누른 게시글 목록인데,
- ReactionArticle을 응답하는건 데이터 낭비로 판단되어
- 게시글 목록만 응답하는것으로 변경

## 설명
- /users/me/like-articles 응답 스키마 수정됨