### PR TITLE
Doc: image api cookie auth swagger 추가

### DIFF
--- a/src/image/image.controller.ts
+++ b/src/image/image.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Post } from '@nestjs/common';
 import {
+  ApiCookieAuth,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -8,6 +9,7 @@ import {
 import { ImageService } from '@image/image.service';
 import { UploadImageUrlResponseDto } from '@image/dto/upload-image-url-response.dto';
 
+@ApiCookieAuth()
 @ApiUnauthorizedResponse({ description: '인증 실패' })
 @ApiTags('Image')
 @Controller('image')


### PR DESCRIPTION
## 바뀐점
- image api에 누락된 Authroize 어노테이션 추가

## 바꾼이유
- 실수로 `@ApiCookieAuth()` 빼먹은거 추가하였음

## 설명
- 실제로는 쿠키를 사용하고 있는데 어노테이션을 빼먹어서 swagger에서 모든 사용자가 사용할 수 있다는 api로 인지될 가능성 있어서 수정함