### PR TITLE
!HOTFIX: 이메일 전송 api에서 나는 구글 에러를 잡기 위해 all filter 적용

### DIFF
--- a/src/ft-auth/ft-auth.controller.ts
+++ b/src/ft-auth/ft-auth.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Post, Get, Query, Render } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  Get,
+  Query,
+  Render,
+  UseFilters,
+} from '@nestjs/common';
 import { FtAuthService } from './ft-auth.service';
 import { GetUser, OnlyNovice, Public } from '@root/auth/auth.decorator';
 import { User } from '@root/user/entities/user.entity';
@@ -11,6 +19,7 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { AllExceptionsFilter } from '@root/filters/all-exception.filter';
 
 @ApiTags('FT Auth')
 @Controller('ft-auth')
@@ -20,6 +29,7 @@ export class FtAuthController {
   @Post()
   @OnlyNovice()
   @ApiCookieAuth()
+  @UseFilters(AllExceptionsFilter)
   @ApiOperation({ summary: '42인증 메일 전송' })
   @ApiOkResponse({ description: '메일 전송 성공' })
   @ApiUnauthorizedResponse({ description: '인증 실패' })


### PR DESCRIPTION
## 바뀐점
- all filter 적용

## 바꾼이유
- 이메일 전송 api에서 생기는 구글 로그인 에러를 잡기 위해 all filter 적용

## 설명
- all filter는 nest에서 정의하지 않은 에러도 처리 할 수 있는 필터이기 때문에 외부 라이브러리나 api에서 생기는 에러를 잡기 위해 사용