### PR TITLE
Fix: docker compose db 헬스체크 스크립트 오류 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - TZ=Asia/Seoul
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     healthcheck:
-      test: 'mysqladmin ping -h localhost -u $$DB_USER_NAME --password=$$DB_USER_PASSWORD'
+      test: 'mysqladmin ping -h localhost -u ${DB_USER_NAME} --password=${DB_USER_PASSWORD}'
       interval: 5s
       timeout: 1s
       retries: 10


### PR DESCRIPTION
## 바뀐점
- docker-compose 파일 내부에 db healthcheck 수정

## 바꾼이유
- 환경 변수를 지정을 제대로 안해줘서 healthcheck가 제대로 안되고 있었음

