### PR TITLE
FIx: slack error hook, prod일때만 알람이 가도록 변경

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,9 @@ export const errorHook = async (
   const slackMessage = `[${phase}] ${exceptionName}: ${exceptionMessage}`;
 
   try {
-    await axios.post(process.env.SLACK_HOOK_URL, { text: slackMessage });
+    if (phase === 'prod') {
+      await axios.post(process.env.SLACK_HOOK_URL, { text: slackMessage });
+    }
   } catch (e) {
     console.error(e);
   }


### PR DESCRIPTION
## 바뀐점
- error hook, prod 일대만 알람이 가도록 변경

## 바꾼이유
- 테스트, 로컬, 알파에서 나는 에러는 굳이 슬랙으로 받을 필요가 없기 때문

