### PR TITLE
Feat: origin 관리를 env로 하도록 변경

### DIFF
--- a/config/sample.env.dev
+++ b/config/sample.env.dev
@@ -21,3 +21,14 @@ EMAIL_HOST=smtp.gmail.com
 EMAIL_FROM_USER_NAME=42world
 EMAIL_ENDPOINT=http://localhost:8888/ft-auth
 FRONT_URL=http://localhost:3000
+
+SLACK_HOOK_URL=
+
+AWS_REGION=
+AWS_ACCESS_KEY=
+AWS_SECRET_KEY=
+AWS_S3_UPLOAD_BUCKET=
+
+ACCESS_TOKEN_KEY=
+
+ORIGIN_LIST=http://localhost:3000,http://localhost:3001

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,8 +33,9 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);
 
+  const originList = process.env.ORIGIN_LIST || '';
   app.enableCors({
-    origin: ['http://localhost:3000', 'https://www.42world.kr'],
+    origin: originList.split(',').map((item) => item.trim()),
     credentials: true,
   });
   app.useGlobalFilters(new TypeormExceptionFilter());


### PR DESCRIPTION
## 바뀐점
- origin 관리를 env로 하도록 변경

## 바꾼이유
- env로 cors를 관리하면 phase에 따라 cors를 다르게 설정하기 편하기 때문에 지금과 같이 변경하였음
- 예를 들면 prod에서는 localhost 접근이 안되게 하는것
