### PR TITLE
Fix: ft-checkin 서초 필드 오타때문에 값이 0으로 나오는 문제 수정

### DIFF
--- a/src/ft-checkin/ft-checkin.service.ts
+++ b/src/ft-checkin/ft-checkin.service.ts
@@ -9,7 +9,7 @@ import axios from 'axios';
 import { ApiProperty } from '@nestjs/swagger';
 
 const GAEPO = 'gaepo';
-const SECHO = 'secho';
+const SEOCHO = 'seocho';
 
 export class GetFtCheckinDto {
   @ApiProperty({ example: 42 })
@@ -36,7 +36,7 @@ export class FtCheckinService {
       try {
         const { data } = await axios.get(endpoint);
         const realData = {
-          seocho: data[SECHO] || 0,
+          seocho: data[SEOCHO] || 0,
           gaepo: data[GAEPO] || 0,
         };
 


### PR DESCRIPTION
## 바뀐점
- ft-checkin 서비스의 상수 변경

## 바꾼이유
- 오타로 인해 값이 없는걸로 나오고 있었음

<img width="423" alt="image" src="https://user-images.githubusercontent.com/8137615/158009797-87bc141c-a114-437c-87e0-c28cc7d883de.png">
