### PR TITLE
Hotfix: pagination skip 오류 수정

### DIFF
--- a/src/article/repositories/article.repository.ts
+++ b/src/article/repositories/article.repository.ts
@@ -6,6 +6,7 @@ import { FindAllBestDto } from '@root/best/dto/find-all-best.dto';
 import { PaginationRequestDto } from '@root/pagination/dto/pagination-request.dto';
 import { PaginationResponseDto } from '@root/pagination/dto/pagination-response.dto';
 import { PageMetaDto } from '@root/pagination/dto/page-meta.dto';
+import { getPaginationSkip } from '@root/utils';
 
 @EntityRepository(Article)
 export class ArticleRepository extends Repository<Article> {
@@ -15,7 +16,7 @@ export class ArticleRepository extends Repository<Article> {
   }> {
     const query = this.createQueryBuilder('article')
       .leftJoinAndSelect('article.writer', 'writer')
-      .skip(options.skip)
+      .skip(getPaginationSkip(options))
       .take(options.take)
       .where('category_id = :id', { id: options.categoryId })
       .orderBy('article.createdAt', options.order);
@@ -56,7 +57,7 @@ export class ArticleRepository extends Repository<Article> {
     const query = this.createQueryBuilder('article')
       .leftJoinAndSelect('article.category', 'category')
       .andWhere('article.writerId = :id', { id: userId })
-      .skip(options.skip)
+      .skip(getPaginationSkip(options))
       .take(options.take)
       .orderBy('article.createdAt', options.order);
 

--- a/src/comment/repositories/comment.repository.ts
+++ b/src/comment/repositories/comment.repository.ts
@@ -4,6 +4,7 @@ import { Comment } from '@comment/entities/comment.entity';
 import { PaginationRequestDto } from '@root/pagination/dto/pagination-request.dto';
 import { PaginationResponseDto } from '@root/pagination/dto/pagination-response.dto';
 import { PageMetaDto } from '@root/pagination/dto/page-meta.dto';
+import { getPaginationSkip } from '@root/utils';
 
 @EntityRepository(Comment)
 export class CommentRepository extends Repository<Comment> {
@@ -17,7 +18,7 @@ export class CommentRepository extends Repository<Comment> {
     const query = this.createQueryBuilder('comment')
       .leftJoinAndSelect('comment.writer', 'writer')
       .andWhere('comment.articleId = :id', { id: articleId })
-      .skip(options.skip)
+      .skip(getPaginationSkip(options))
       .take(options.take)
       .orderBy('comment.createdAt', options.order);
 
@@ -38,13 +39,13 @@ export class CommentRepository extends Repository<Comment> {
 
   async findAllMyComment(
     userId: number,
-    options?: PaginationRequestDto,
+    options: PaginationRequestDto,
   ): Promise<PaginationResponseDto<Comment>> {
     const query = this.createQueryBuilder('comment')
       .leftJoinAndSelect('comment.article', 'article')
       .leftJoinAndSelect('article.category', 'category')
       .andWhere('comment.writerId = :id', { id: userId })
-      .skip(options.skip)
+      .skip(getPaginationSkip(options))
       .take(options.take)
       .orderBy('comment.createdAt', options.order);
 

--- a/src/database/seeder/user/data.ts
+++ b/src/database/seeder/user/data.ts
@@ -13,12 +13,16 @@ export const users: SeederDataUser[] = [
   {
     id: 1,
     oauthToken: 'test1234',
+    githubUsername: 'string1',
+    githubUid: 'string2',
     nickname: 'first user',
     role: UserRole.CADET,
   },
   {
     id: 2,
     oauthToken: 'test2345',
+    githubUsername: 'string2',
+    githubUid: 'string3',
     nickname: 'second user',
     role: UserRole.NOVICE,
   },

--- a/src/pagination/dto/pagination-request.dto.ts
+++ b/src/pagination/dto/pagination-request.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Exclude, Type } from 'class-transformer';
+import { Type } from 'class-transformer';
 import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
 import { Order } from '../interface/pagination.enum';
 
@@ -31,11 +31,4 @@ export class PaginationRequestDto {
   @Max(1000)
   @IsOptional()
   readonly take?: number = 10;
-
-  @Exclude({
-    toClassOnly: true,
-  })
-  get skip(): number {
-    return (this.page - 1) * this.take;
-  }
 }

--- a/src/reaction/repositories/reaction-article.repository.ts
+++ b/src/reaction/repositories/reaction-article.repository.ts
@@ -1,6 +1,7 @@
 import { PageMetaDto } from '@root/pagination/dto/page-meta.dto';
 import { PaginationRequestDto } from '@root/pagination/dto/pagination-request.dto';
 import { PaginationResponseDto } from '@root/pagination/dto/pagination-response.dto';
+import { getPaginationSkip } from '@root/utils';
 import { EntityRepository, Repository } from 'typeorm';
 import {
   ReactionArticle,
@@ -27,7 +28,7 @@ export class ReactionArticleRepository extends Repository<ReactionArticle> {
       .leftJoinAndSelect('reactionArticle.article', 'article')
       .leftJoinAndSelect('article.category', 'category')
       .andWhere('reactionArticle.userId = :id', { id: userId })
-      .skip(options.skip)
+      .skip(getPaginationSkip(options))
       .take(options.take)
       .orderBy('reactionArticle.createdAt', options.order);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { CookieOptions } from 'express';
 import axios from 'axios';
+import { PaginationRequestDto } from './pagination/dto/pagination-request.dto';
 
 export const MINUTE = 60;
 export const HOUR = 60 * MINUTE;
@@ -42,4 +43,8 @@ export const errorHook = async (
   } catch (e) {
     console.error(e);
   }
+};
+
+export const getPaginationSkip = (paginationDto: PaginationRequestDto) => {
+  return (paginationDto.page - 1) * paginationDto.take;
 };


### PR DESCRIPTION
## 바뀐점
페이지네이션에서 skip 속성을 가져오지 못해서 utils에서 따로 처리하도록 변경

## 바꾼이유
IntersectionType 을 사용할떄, skip 속성을 가져오지 않아서, skip이 undefined 가 된다.

## 설명
utils에 getPaginationSkip 함수를 하나 만들어서 사용하도록 변경했습니다.