### PR TITLE
Feat: github action을 통한 test workflow 추가

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,5 +42,4 @@ jobs:
       - name: GitHub Action for Yarn
         uses: Borales/actions-yarn@v2.3.0
       - run: ./run_test_db.sh
-      - run: yarn
       - run: yarn test:e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    env:
+      DB_HOST: ${{secrets.DB_HOST}}
+      DB_NAME: ${{secrets.DB_NAME}}
+      DB_PORT: ${{secrets.DB_PORT}}
+      DB_USER_NAME: ${{secrets.DB_USER_NAME}}
+      DB_USER_PASSWORD: ${{secrets.DB_USER_PASSWORD}}
+      JWT_SECRET: ${{secrets.JWT_SECRET}}
+      GITHUB_CALLBACK_URL: ${{secrets.NEST_GITHUB_CALLBACK_URL}}
+      GITHUB_CLIENT_ID: ${{secrets.NEST_GITHUB_CLIENT_ID}}
+      GITHUB_CLIENT_SECRET: ${{secrets.NEST_GITHUB_CLIENT_SECRET}}
+      AWS_REGION: ${{secrets.AWS_REGION}}
+      AWS_ACCESS_KEY: ${{secrets.AWS_ACCESS_KEY}}
+      AWS_SECRET_KEY: ${{secrets.AWS_SECRET_KEY}}
+      AWS_S3_UPLOAD_BUCKET: ${{secrets.AWS_S3_UPLOAD_BUCKET}}
+      ACCESS_TOKEN_KEY: ${{secrets.ACCESS_TOKEN_KEY}}
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: GitHub Action for Yarn
+        uses: Borales/actions-yarn@v2.3.0
+      - run: ./run_test_db.sh
+      - run: yarn
+      - run: yarn test:e2e


### PR DESCRIPTION
## 바뀐점
- github action을 통한 test cli 추가

## 바꾼이유
- 올라온 pr의 테스트 코드 실행 여부를 매번 확인하기 어려워서 추가

## 설명
- github secret을 이용할때 GITHUB으로 시작하는 secret이 존재하면 등록되지 않아서 github 관련 env는 NEST_를 붙여서 등록하였음
- 실제 env로 사용할때는 workflow에서 제대로 들어가도록 지정했기 때문에 문제 없음