### PR TITLE
Feat: 유저 테스트 케이스 추가

### DIFF
--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -225,7 +225,7 @@ describe('User', () => {
 
       const updatedUser = await userRepository.findOne(user.id);
       expect(updatedUser.nickname).toEqual(updatedNickname);
-      expect(updatedUser.character).toEqual(0);
+      expect(updatedUser.character).toEqual(user.character);
     });
 
     test('[성공] PUT - 캐릭터만 변경하는 경우', async () => {
@@ -246,7 +246,7 @@ describe('User', () => {
 
     test('[실패] PUT - 없는 캐릭터 번호', async () => {
       const updateData = {
-        nickname: 'rockpell',
+        nickname: updatedNickname,
         character: 999,
       } as UpdateUserProfileRequestDto;
       const response = await request(httpServer)
@@ -325,9 +325,9 @@ describe('User', () => {
 
     beforeEach(async () => {
       user = dummy.user(
-        'test1234',
-        'first user',
-        'githubUsername',
+        'test github uid',
+        'test nickname',
+        'github user name',
         UserRole.CADET,
       );
       await userRepository.save(user);
@@ -367,9 +367,9 @@ describe('User', () => {
 
     beforeEach(async () => {
       user = dummy.user(
-        'test1234',
-        'first user',
-        'githubUsername',
+        'test github uid',
+        'test nickname',
+        'github user name',
         UserRole.CADET,
       );
       await userRepository.save(user);
@@ -380,9 +380,9 @@ describe('User', () => {
 
       category = dummy.category('자유게시판');
       await categoryRepository.save(category);
-      article = dummy.article(category.id, user.id, 'a', 'bb');
+      article = dummy.article(category.id, user.id, 'title', 'content');
       await articleRepository.save(article);
-      comment = dummy.comment(user.id, user.id, 'cc');
+      comment = dummy.comment(user.id, user.id, 'content');
       await commentRepository.save(comment);
       reactionArticle = dummy.reactionArticle(article.id, user.id);
       await reactionArticleRepository.save(reactionArticle);

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -9,7 +9,7 @@ import { CategoryRepository } from '@category/repositories/category.repository';
 import { CommentModule } from '@comment/comment.module';
 import { Comment } from '@comment/entities/comment.entity';
 import { CommentRepository } from '@comment/repositories/comment.repository';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeormExceptionFilter } from '@root/filters/typeorm-exception.filter';
 import { ReactionModule } from '@root/reaction/reaction.module';
@@ -107,7 +107,7 @@ describe('UserController (e2e)', () => {
         .get('/users/me')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
     });
   });
 
@@ -133,7 +133,7 @@ describe('UserController (e2e)', () => {
         .get(`/users/${user.id}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
       expect(response.body.id).toEqual(user.id);
       expect(response.body.nickname).toEqual(user.nickname);
     });
@@ -145,7 +145,7 @@ describe('UserController (e2e)', () => {
 
       // 404를 던지는게 원래 맞는 건가요
       // TODO - 스웨거에 반영하기
-      expect(response.status).toEqual(404);
+      expect(response.status).toEqual(HttpStatus.NOT_FOUND);
     });
   });
 
@@ -184,7 +184,7 @@ describe('UserController (e2e)', () => {
         .send(updateData)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const updatedUser = await userRepository.findOne(user.id);
       expect(updatedUser.nickname).toEqual('rockpell');
@@ -202,7 +202,7 @@ describe('UserController (e2e)', () => {
         .send(updateData)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const updatedUser = await userRepository.findOne(user.id);
       expect(updatedUser.nickname).toEqual(user2.nickname);
@@ -220,7 +220,7 @@ describe('UserController (e2e)', () => {
         .send(updateData)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const updatedUser = await userRepository.findOne(user.id);
       expect(updatedUser.nickname).toEqual('');
@@ -236,7 +236,7 @@ describe('UserController (e2e)', () => {
         .send(updateData)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const updatedUser = await userRepository.findOne(user.id);
       expect(updatedUser.nickname).toEqual('mimseong');
@@ -252,7 +252,7 @@ describe('UserController (e2e)', () => {
         .send(updateData)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const updatedUser = await userRepository.findOne(user.id);
       expect(updatedUser.nickname).toEqual(user.nickname);
@@ -270,7 +270,7 @@ describe('UserController (e2e)', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
       // TODO - 스웨거에 반영하기
-      expect(response.status).toEqual(400);
+      expect(response.status).toEqual(HttpStatus.NOT_FOUND);
 
       const updatedUser = await userRepository.findOne(user.id);
       expect(updatedUser.nickname).toEqual(user.nickname);
@@ -282,7 +282,7 @@ describe('UserController (e2e)', () => {
         .delete('/users')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const deletedUser = await userRepository.findOne(user.id, {
         withDeleted: true,
@@ -321,7 +321,7 @@ describe('UserController (e2e)', () => {
         .get('/users/me/articles')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const articles = response.body.data as Article[];
 
@@ -361,7 +361,7 @@ describe('UserController (e2e)', () => {
         .get('/users/me/comments')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const comments = response.body.data as Comment[];
 
@@ -405,7 +405,7 @@ describe('UserController (e2e)', () => {
         .get('/users/me/like-articles')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const articles = response.body.data as Article[];
 

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -152,6 +152,7 @@ describe('UserController (e2e)', () => {
   describe('/users', () => {
     let user: User;
     let user2: User;
+    const updatedNickname = 'updated nickname';
 
     beforeEach(async () => {
       user = dummy.user(
@@ -176,7 +177,7 @@ describe('UserController (e2e)', () => {
 
     test('[성공] PUT - 유저 프로필 변경', async () => {
       const updateData = {
-        nickname: 'rockpell',
+        nickname: updatedNickname,
         character: 2,
       } as UpdateUserProfileRequestDto;
       const response = await request(app)
@@ -187,7 +188,7 @@ describe('UserController (e2e)', () => {
       expect(response.status).toEqual(HttpStatus.OK);
 
       const updatedUser = await userRepository.findOne(user.id);
-      expect(updatedUser.nickname).toEqual('rockpell');
+      expect(updatedUser.nickname).toEqual(updatedNickname);
       expect(updatedUser.character).toEqual(2);
     });
 
@@ -229,7 +230,7 @@ describe('UserController (e2e)', () => {
 
     test('[성공] PUT - 닉네임만 변경하는 경우', async () => {
       const updateData = {
-        nickname: 'mimseong',
+        nickname: updatedNickname,
       } as UpdateUserProfileRequestDto;
       const response = await request(app)
         .put('/users')
@@ -239,7 +240,7 @@ describe('UserController (e2e)', () => {
       expect(response.status).toEqual(HttpStatus.OK);
 
       const updatedUser = await userRepository.findOne(user.id);
-      expect(updatedUser.nickname).toEqual('mimseong');
+      expect(updatedUser.nickname).toEqual(updatedNickname);
       expect(updatedUser.character).toEqual(0);
     });
 

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -18,6 +18,7 @@ import { UpdateUserProfileRequestDto } from '@root/user/dto/request/update-user-
 import { UserRole } from '@root/user/interfaces/userrole.interface';
 import * as dummy from '@test/e2e/utils/dummy';
 import { clearDB } from '@test/e2e/utils/utils';
+import { User } from '@user/entities/user.entity';
 import { UserRepository } from '@user/repositories/user.repository';
 import { UserModule } from '@user/user.module';
 import * as cookieParser from 'cookie-parser';
@@ -87,17 +88,17 @@ describe('UserController (e2e)', () => {
 
   describe('/users/me', () => {
     beforeEach(async () => {
-      const newUser = dummy.user(
-        'test1234',
-        'first user',
-        'githubUsername',
+      const user = dummy.user(
+        'test github uid',
+        'test nickname',
+        'github user name',
         UserRole.CADET,
       );
-      await userRepository.save(newUser);
+      await userRepository.save(user);
 
       JWT = authService.getJWT({
-        userId: newUser.id,
-        userRole: newUser.role,
+        userId: user.id,
+        userRole: user.role,
       } as JWTPayload);
     });
 
@@ -111,13 +112,13 @@ describe('UserController (e2e)', () => {
   });
 
   describe('/users/{id}', () => {
-    let user;
+    let user: User;
 
     beforeEach(async () => {
       user = dummy.user(
-        'test1234',
-        'first user',
-        'githubUsername',
+        'test github uid',
+        'test nickname',
+        'github user name',
         UserRole.CADET,
       );
       await userRepository.save(user);
@@ -149,17 +150,19 @@ describe('UserController (e2e)', () => {
   });
 
   describe('/users', () => {
-    let user;
-    const githubUid = 'test github uid';
-    const nickname = 'test nickname';
-    const nickname2 = 'test nickname2';
-    const githubUsername = 'github user name';
+    let user: User;
+    let user2: User;
 
     beforeEach(async () => {
-      user = dummy.user(githubUid, nickname, githubUsername, UserRole.CADET);
-      const user2 = dummy.user(
+      user = dummy.user(
+        'test github uid',
+        'test nickname',
+        'github user name',
+        UserRole.CADET,
+      );
+      user2 = dummy.user(
         'test github uid2',
-        nickname2,
+        'test nickname2',
         'github user name2',
         UserRole.CADET,
       );
@@ -191,7 +194,7 @@ describe('UserController (e2e)', () => {
     test('[성공] PUT - 중복된 닉네임인 경우', async () => {
       // nickname2는 유저2의 닉네임이다
       const updateData = {
-        nickname: nickname2,
+        nickname: user2.nickname,
         character: 2,
       } as UpdateUserProfileRequestDto;
       const response = await request(app)
@@ -202,7 +205,7 @@ describe('UserController (e2e)', () => {
       expect(response.status).toEqual(200);
 
       const updatedUser = await userRepository.findOne(user.id);
-      expect(updatedUser.nickname).toEqual(nickname2);
+      expect(updatedUser.nickname).toEqual(user2.nickname);
       expect(updatedUser.character).toEqual(2);
     });
 
@@ -252,7 +255,7 @@ describe('UserController (e2e)', () => {
       expect(response.status).toEqual(200);
 
       const updatedUser = await userRepository.findOne(user.id);
-      expect(updatedUser.nickname).toEqual(nickname);
+      expect(updatedUser.nickname).toEqual(user.nickname);
       expect(updatedUser.character).toEqual(2);
     });
 
@@ -270,7 +273,7 @@ describe('UserController (e2e)', () => {
       expect(response.status).toEqual(400);
 
       const updatedUser = await userRepository.findOne(user.id);
-      expect(updatedUser.nickname).toEqual(nickname);
+      expect(updatedUser.nickname).toEqual(user.nickname);
       expect(updatedUser.character).toEqual(0);
     });
 
@@ -290,15 +293,15 @@ describe('UserController (e2e)', () => {
   });
 
   describe('/users/me/articles', () => {
-    let user;
+    let user: User;
     let category;
     let article;
 
     beforeEach(async () => {
       user = dummy.user(
-        'test1234',
-        'first user',
-        'githubUsername',
+        'test github uid',
+        'test nickname',
+        'github user name',
         UserRole.CADET,
       );
       await userRepository.save(user);

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -26,7 +26,7 @@ import * as request from 'supertest';
 import { getConnection } from 'typeorm';
 import { TestBaseModule } from './test.base.module';
 
-describe('UserController (e2e)', () => {
+describe('User', () => {
   let app: INestApplication;
   let userRepository: UserRepository;
   let articleRepository: ArticleRepository;

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -271,7 +271,7 @@ describe('User', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
       // TODO - 스웨거에 반영하기
-      expect(response.status).toEqual(HttpStatus.NOT_FOUND);
+      expect(response.status).toEqual(HttpStatus.BAD_REQUEST);
 
       const updatedUser = await userRepository.findOne(user.id);
       expect(updatedUser.nickname).toEqual(user.nickname);

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -152,11 +152,19 @@ describe('UserController (e2e)', () => {
     let user;
     const githubUid = 'test github uid';
     const nickname = 'test nickname';
+    const nickname2 = 'test nickname2';
     const githubUsername = 'github user name';
 
     beforeEach(async () => {
       user = dummy.user(githubUid, nickname, githubUsername, UserRole.CADET);
+      const user2 = dummy.user(
+        'test github uid2',
+        nickname2,
+        'github user name2',
+        UserRole.CADET,
+      );
       await userRepository.save(user);
+      await userRepository.save(user2);
       JWT = authService.getJWT({
         userId: user.id,
         userRole: user.role,
@@ -177,6 +185,24 @@ describe('UserController (e2e)', () => {
 
       const updatedUser = await userRepository.findOne(user.id);
       expect(updatedUser.nickname).toEqual('rockpell');
+      expect(updatedUser.character).toEqual(2);
+    });
+
+    test('[성공] PUT - 중복된 닉네임인 경우', async () => {
+      // nickname2는 유저2의 닉네임이다
+      const updateData = {
+        nickname: nickname2,
+        character: 2,
+      } as UpdateUserProfileRequestDto;
+      const response = await request(app)
+        .put('/users')
+        .send(updateData)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
+
+      expect(response.status).toEqual(200);
+
+      const updatedUser = await userRepository.findOne(user.id);
+      expect(updatedUser.nickname).toEqual(nickname2);
       expect(updatedUser.character).toEqual(2);
     });
 

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -48,6 +48,7 @@ describe('User', () => {
     }).compile();
 
     const app = createTestApp(moduleFixture);
+    await app.init();
 
     userRepository = moduleFixture.get(UserRepository);
     articleRepository = moduleFixture.get(ArticleRepository);
@@ -86,7 +87,7 @@ describe('User', () => {
     });
 
     test('[성공] GET - 내 정보 가져오기', async () => {
-      const response = await request(app)
+      const response = await request(httpServer)
         .get('/users/me')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
@@ -112,7 +113,7 @@ describe('User', () => {
     });
 
     test('[성공] GET - 특정 유저 정보 가져오기', async () => {
-      const response = await request(app)
+      const response = await request(httpServer)
         .get(`/users/${user.id}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
@@ -122,7 +123,7 @@ describe('User', () => {
     });
 
     test('[실패] GET - 없는 유저 id를 요청한 경우', async () => {
-      const response = await request(app)
+      const response = await request(httpServer)
         .get(`/users/${999}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
@@ -163,7 +164,7 @@ describe('User', () => {
         nickname: updatedNickname,
         character: 2,
       } as UpdateUserProfileRequestDto;
-      const response = await request(app)
+      const response = await request(httpServer)
         .put('/users')
         .send(updateData)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
@@ -181,7 +182,7 @@ describe('User', () => {
         nickname: user2.nickname,
         character: 2,
       } as UpdateUserProfileRequestDto;
-      const response = await request(app)
+      const response = await request(httpServer)
         .put('/users')
         .send(updateData)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
@@ -199,7 +200,7 @@ describe('User', () => {
         nickname: '',
         character: 2,
       } as UpdateUserProfileRequestDto;
-      const response = await request(app)
+      const response = await request(httpServer)
         .put('/users')
         .send(updateData)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
@@ -215,7 +216,7 @@ describe('User', () => {
       const updateData = {
         nickname: updatedNickname,
       } as UpdateUserProfileRequestDto;
-      const response = await request(app)
+      const response = await request(httpServer)
         .put('/users')
         .send(updateData)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
@@ -231,7 +232,7 @@ describe('User', () => {
       const updateData = {
         character: 2,
       } as UpdateUserProfileRequestDto;
-      const response = await request(app)
+      const response = await request(httpServer)
         .put('/users')
         .send(updateData)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
@@ -248,7 +249,7 @@ describe('User', () => {
         nickname: 'rockpell',
         character: 999,
       } as UpdateUserProfileRequestDto;
-      const response = await request(app)
+      const response = await request(httpServer)
         .put('/users')
         .send(updateData)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
@@ -262,7 +263,7 @@ describe('User', () => {
     });
 
     test('[성공] DELETE - 유저 삭제하기', async () => {
-      const response = await request(app)
+      const response = await request(httpServer)
         .delete('/users')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
@@ -301,7 +302,7 @@ describe('User', () => {
     });
 
     test('[성공] GET - 내가 작성한 글 가져오기', async () => {
-      const response = await request(app)
+      const response = await request(httpServer)
         .get('/users/me/articles')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
@@ -341,7 +342,7 @@ describe('User', () => {
     });
 
     test('[성공] GET - 내가 작성한 댓글 가져오기', async () => {
-      const response = await request(app)
+      const response = await request(httpServer)
         .get('/users/me/comments')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
@@ -385,7 +386,7 @@ describe('User', () => {
     });
 
     test('[성공] GET - 내가 좋아요 누른 게시글 목록 확인', async () => {
-      const response = await request(app)
+      const response = await request(httpServer)
         .get('/users/me/like-articles')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -1,30 +1,29 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import * as request from 'supertest';
-import { getConnection } from 'typeorm';
-import * as cookieParser from 'cookie-parser';
-
-import { AuthModule } from '@auth/auth.module';
-import { UserModule } from '@user/user.module';
-import { UserRepository } from '@user/repositories/user.repository';
-import { JWTPayload } from '@auth/interfaces/jwt-payload.interface';
-import { AuthService } from '@auth/auth.service';
-import { TestBaseModule } from './test.base.module';
-import { TypeormExceptionFilter } from '@root/filters/typeorm-exception.filter';
 import { ArticleModule } from '@article/article.module';
-import { ArticleRepository } from '@article/repositories/article.repository';
 import { Article } from '@article/entities/article.entity';
-import { UpdateUserProfileRequestDto } from '@root/user/dto/request/update-user-profile-request.dto';
+import { ArticleRepository } from '@article/repositories/article.repository';
+import { AuthModule } from '@auth/auth.module';
+import { AuthService } from '@auth/auth.service';
+import { JWTPayload } from '@auth/interfaces/jwt-payload.interface';
 import { CategoryModule } from '@category/category.module';
 import { CategoryRepository } from '@category/repositories/category.repository';
-import { Comment } from '@comment/entities/comment.entity';
 import { CommentModule } from '@comment/comment.module';
+import { Comment } from '@comment/entities/comment.entity';
 import { CommentRepository } from '@comment/repositories/comment.repository';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeormExceptionFilter } from '@root/filters/typeorm-exception.filter';
 import { ReactionModule } from '@root/reaction/reaction.module';
 import { ReactionArticleRepository } from '@root/reaction/repositories/reaction-article.repository';
+import { UpdateUserProfileRequestDto } from '@root/user/dto/request/update-user-profile-request.dto';
 import { UserRole } from '@root/user/interfaces/userrole.interface';
-import { clearDB } from '@test/e2e/utils/utils';
 import * as dummy from '@test/e2e/utils/dummy';
+import { clearDB } from '@test/e2e/utils/utils';
+import { UserRepository } from '@user/repositories/user.repository';
+import { UserModule } from '@user/user.module';
+import * as cookieParser from 'cookie-parser';
+import * as request from 'supertest';
+import { getConnection } from 'typeorm';
+import { TestBaseModule } from './test.base.module';
 
 describe('UserController (e2e)', () => {
   let app: INestApplication;
@@ -137,18 +136,26 @@ describe('UserController (e2e)', () => {
       expect(response.body.id).toEqual(user.id);
       expect(response.body.nickname).toEqual(user.nickname);
     });
+
+    test('[실패] GET - 없는 유저 id를 요청한 경우', async () => {
+      const response = await request(app)
+        .get(`/users/${999}`)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
+
+      // 404를 던지는게 원래 맞는 건가요
+      // TODO - 스웨거에 반영하기
+      expect(response.status).toEqual(404);
+    });
   });
 
   describe('/users', () => {
     let user;
+    const githubUid = 'test github uid';
+    const nickname = 'test nickname';
+    const githubUsername = 'github user name';
 
     beforeEach(async () => {
-      user = dummy.user(
-        'test1234',
-        'first user',
-        'githubUsername',
-        UserRole.CADET,
-      );
+      user = dummy.user(githubUid, nickname, githubUsername, UserRole.CADET);
       await userRepository.save(user);
       JWT = authService.getJWT({
         userId: user.id,
@@ -161,7 +168,6 @@ describe('UserController (e2e)', () => {
         nickname: 'rockpell',
         character: 2,
       } as UpdateUserProfileRequestDto;
-
       const response = await request(app)
         .put('/users')
         .send(updateData)
@@ -172,6 +178,74 @@ describe('UserController (e2e)', () => {
       const updatedUser = await userRepository.findOne(user.id);
       expect(updatedUser.nickname).toEqual('rockpell');
       expect(updatedUser.character).toEqual(2);
+    });
+
+    // TODO - 이게 올바른 동작인지 확인
+    test('[성공] PUT - 닉네임 길이가 0인 경우', async () => {
+      const updateData = {
+        nickname: '',
+        character: 2,
+      } as UpdateUserProfileRequestDto;
+      const response = await request(app)
+        .put('/users')
+        .send(updateData)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
+
+      expect(response.status).toEqual(200);
+
+      const updatedUser = await userRepository.findOne(user.id);
+      expect(updatedUser.nickname).toEqual('');
+      expect(updatedUser.character).toEqual(2);
+    });
+
+    test('[성공] PUT - 닉네임만 변경하는 경우', async () => {
+      const updateData = {
+        nickname: 'mimseong',
+      } as UpdateUserProfileRequestDto;
+      const response = await request(app)
+        .put('/users')
+        .send(updateData)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
+
+      expect(response.status).toEqual(200);
+
+      const updatedUser = await userRepository.findOne(user.id);
+      expect(updatedUser.nickname).toEqual('mimseong');
+      expect(updatedUser.character).toEqual(0);
+    });
+
+    test('[성공] PUT - 캐릭터만 변경하는 경우', async () => {
+      const updateData = {
+        character: 2,
+      } as UpdateUserProfileRequestDto;
+      const response = await request(app)
+        .put('/users')
+        .send(updateData)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
+
+      expect(response.status).toEqual(200);
+
+      const updatedUser = await userRepository.findOne(user.id);
+      expect(updatedUser.nickname).toEqual(nickname);
+      expect(updatedUser.character).toEqual(2);
+    });
+
+    test('[실패] PUT - 없는 캐릭터 번호', async () => {
+      const updateData = {
+        nickname: 'rockpell',
+        character: 999,
+      } as UpdateUserProfileRequestDto;
+      const response = await request(app)
+        .put('/users')
+        .send(updateData)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
+
+      // TODO - 스웨거에 반영하기
+      expect(response.status).toEqual(400);
+
+      const updatedUser = await userRepository.findOne(user.id);
+      expect(updatedUser.nickname).toEqual(nickname);
+      expect(updatedUser.character).toEqual(0);
     });
 
     test('[성공] DELETE - 유저 삭제하기', async () => {

--- a/test/e2e/utils/dummy.ts
+++ b/test/e2e/utils/dummy.ts
@@ -34,9 +34,8 @@ export const jwt = (
   } as JWTPayload);
 };
 
-export const category = (name: string, id = 1) => {
+export const category = (name: string) => {
   const category = new Category();
-  category.id = id;
   category.name = name;
   return category;
 };

--- a/test/e2e/utils/dummy.ts
+++ b/test/e2e/utils/dummy.ts
@@ -12,11 +12,13 @@ export const user = (
   nickname: string,
   githubUsername: string,
   role: UserRole,
+  character = 0,
 ): User => {
   const user = new User();
   user.githubUid = githubUid;
   user.nickname = nickname;
   user.githubUsername = githubUsername;
+  user.character = character;
   user.role = role;
   return user;
 };
@@ -32,8 +34,9 @@ export const jwt = (
   } as JWTPayload);
 };
 
-export const category = (name: string) => {
+export const category = (name: string, id = 1) => {
   const category = new Category();
+  category.id = id;
   category.name = name;
   return category;
 };

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -1,4 +1,10 @@
 import { getConnection } from 'typeorm';
+import * as cookieParser from 'cookie-parser';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { TestingModule } from '@nestjs/testing';
+
+import { InternalServerErrorExceptionFilter } from '@root/filters/internal-server-error-exception.filter';
+import { TypeormExceptionFilter } from '@root/filters/typeorm-exception.filter';
 
 export const clearDB = async () => {
   const entities = getConnection().entityMetadatas;
@@ -6,4 +12,22 @@ export const clearDB = async () => {
     const repository = getConnection().getRepository(entity.name);
     await repository.query(`TRUNCATE TABLE ${entity.tableName}`);
   }
+};
+
+export const createTestApp = (
+  moduleFixture: TestingModule,
+): INestApplication => {
+  const app = moduleFixture.createNestApplication();
+
+  app.use(cookieParser());
+  app.useGlobalFilters(new InternalServerErrorExceptionFilter());
+  app.useGlobalFilters(new TypeormExceptionFilter());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+  return app;
 };


### PR DESCRIPTION
## 바뀐점
- 유저 테스트의 부족한 테스트 케이스를 추가했습니다

## 바꾼이유
- 테스트 보강을 위해 변경했습니다

## 설명
- /users/{id} [실패] GET - 없는 유저 id를 요청한 경우
- /users [성공] PUT - 닉네임 길이가 0인 경우
- /users [성공] PUT - 닉네임만 변경하는 경우
- /users [성공] PUT - 캐릭터만 변경하는 경우
- /users [성공] PUT - 중복된 닉네임인 경우
- /users [실패] PUT - 없는 캐릭터 번호

위 테스트 케이스를 추가했습니다.
몇몇 실패 케이스는 스웨거에 반영이 안 된 경우가 있어 추후에 반영하면 좋을 것 같아요
주석을 확인해주면 감사합니다

![image](https://user-images.githubusercontent.com/50068946/160285633-785cc61c-a926-414d-bd48-2e66d6d82256.png)

