### PR TITLE
Feat: intra-auth 메일 인증 test 추가

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       AWS_SECRET_KEY: ${{secrets.AWS_SECRET_KEY}}
       AWS_S3_UPLOAD_BUCKET: ${{secrets.AWS_S3_UPLOAD_BUCKET}}
       ACCESS_TOKEN_KEY: ${{secrets.ACCESS_TOKEN_KEY}}
+      FRONT_URL: ${{secrets.FRONT_URL}}
 
     strategy:
       matrix:

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "supertest": "^6.1.3",
     "ts-jest": "^27.0.3",
     "ts-loader": "^9.2.3",
+    "ts-mockito": "^2.6.1",
     "ts-node": "^10.0.0",
     "tsconfig-paths": "^3.10.1",
     "typescript": "^4.3.5"

--- a/src/intra-auth/intra-auth.controller.ts
+++ b/src/intra-auth/intra-auth.controller.ts
@@ -48,8 +48,7 @@ export class IntraAuthController {
   @Render('intra-auth/results.ejs')
   @Public() // TODO: check this
   @ApiOperation({ summary: '42인증 메일 코드 확인' })
-  @ApiOkResponse({ description: '42인증 완료' })
-  @ApiForbiddenResponse({ description: '42인증 메일 코드 만료됨' })
+  @ApiOkResponse({ description: 'results.ejs 파일 렌더링' })
   async getAuthCode(@Query('code') code: string) {
     try {
       await this.intraAuthService.getAuth(code);

--- a/src/intra-auth/intra-auth.controller.ts
+++ b/src/intra-auth/intra-auth.controller.ts
@@ -45,7 +45,7 @@ export class IntraAuthController {
   }
 
   @Get()
-  @Render('results.ejs')
+  @Render('intra-auth/results.ejs')
   @Public() // TODO: check this
   @ApiOperation({ summary: '42인증 메일 코드 확인' })
   @ApiOkResponse({ description: '42인증 완료' })

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ async function bootstrap() {
     }),
   );
   app.useStaticAssets(join(__dirname, '..', 'public'));
-  app.setBaseViewsDir(join(__dirname, '..', 'views/intra-auth'));
+  app.setBaseViewsDir(join(__dirname, '..', 'views'));
   app.setViewEngine('ejs');
   app.use(cookieParser());
   await app.listen(port || 3000);

--- a/test/e2e/intra-auth.e2e-spec.ts
+++ b/test/e2e/intra-auth.e2e-spec.ts
@@ -21,6 +21,7 @@ import { CacheService } from '@cache/cache.service';
 import { MailerService } from '@nestjs-modules/mailer';
 import { UserRole } from '@user/interfaces/userrole.interface';
 import { IntraAuthMailDto } from '@cache/dto/intra-auth.dto';
+import { User } from '@user/entities/user.entity';
 
 describe('IntraAuth', () => {
   let httpServer: INestApplication;
@@ -72,7 +73,9 @@ describe('IntraAuth', () => {
   });
 
   describe('/intra-auth', () => {
-    let newUser;
+    let newUser: User;
+    const intraId = 'rockpell';
+
     beforeEach(async () => {
       newUser = dummy.user(
         'test1',
@@ -102,7 +105,7 @@ describe('IntraAuth', () => {
       const response = await request(httpServer)
         .post('/intra-auth')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`)
-        .send({ intraId: 'rockpell' });
+        .send({ intraId });
 
       expect(response.status).toEqual(HttpStatus.CREATED);
     });
@@ -111,7 +114,7 @@ describe('IntraAuth', () => {
       const response = await request(httpServer)
         .post('/intra-auth')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${cadetJWT}`)
-        .send({ intraId: 'rockpell' });
+        .send({ intraId });
 
       expect(response.status).toEqual(HttpStatus.INTERNAL_SERVER_ERROR);
 
@@ -121,14 +124,16 @@ describe('IntraAuth', () => {
     });
 
     test('[성공] GET - 이메일 인증', async () => {
-      when(cacheService.getIntraAuthMailData('code')).thenResolve(
-        new IntraAuthMailDto(newUser.id, 'intraId'),
+      const mailCode = 'code';
+
+      when(cacheService.getIntraAuthMailData(mailCode)).thenResolve(
+        new IntraAuthMailDto(newUser.id, intraId),
       );
 
       const response = await request(httpServer)
         .get('/intra-auth')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`)
-        .query({ code: 'code' });
+        .query({ code: mailCode });
 
       let resultEjs: string;
       try {

--- a/test/e2e/intra-auth.e2e-spec.ts
+++ b/test/e2e/intra-auth.e2e-spec.ts
@@ -78,16 +78,16 @@ describe('IntraAuth', () => {
 
     beforeEach(async () => {
       newUser = dummy.user(
-        'test1',
-        'first user',
+        'user githubUid',
+        'user',
         'githubUsername',
         UserRole.NOVICE,
       );
       await userRepository.save(newUser);
 
       const cadetUser = dummy.user(
-        'test2',
-        'first user2',
+        'user2 githubUid',
+        'user2',
         'githubUsername2',
         UserRole.CADET,
       );

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -1,4 +1,10 @@
 import { getConnection } from 'typeorm';
+import * as cookieParser from 'cookie-parser';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { TestingModule } from '@nestjs/testing';
+
+import { InternalServerErrorExceptionFilter } from '@root/filters/internal-server-error-exception.filter';
+import { TypeormExceptionFilter } from '@root/filters/typeorm-exception.filter';
 
 export const clearDB = async () => {
   const entities = getConnection().entityMetadatas;
@@ -6,4 +12,22 @@ export const clearDB = async () => {
     const repository = getConnection().getRepository(entity.name);
     await repository.query(`TRUNCATE TABLE ${entity.tableName}`);
   }
+};
+
+export const createTestApp = (
+  moduleFixture: TestingModule,
+): INestApplication => {
+  const app = moduleFixture.createNestApplication();
+
+  app.use(cookieParser());
+  app.useGlobalFilters(new InternalServerErrorExceptionFilter());
+  app.useGlobalFilters(new TypeormExceptionFilter());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+  return app;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4687,7 +4687,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@4.17.21, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
+lodash@4.17.21, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6588,6 +6588,13 @@ ts-loader@^9.2.3:
     enhanced-resolve "^5.0.0"
     micromatch "^4.0.0"
     semver "^7.3.4"
+
+ts-mockito@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/ts-mockito/-/ts-mockito-2.6.1.tgz#bc9ee2619033934e6fad1c4455aca5b5ace34e73"
+  integrity sha512-qU9m/oEBQrKq5hwfbJ7MgmVN5Gu6lFnIGWvpxSjrqq6YYEVv+RwVFWySbZMBgazsWqv6ctAyVBpo9TmAxnOEKw==
+  dependencies:
+    lodash "^4.17.5"
 
 ts-node@^10.0.0:
   version "10.4.0"


### PR DESCRIPTION
## 바뀐점
- intra-auth 이메일 인증, get api test 추가
- createTestApp 유틸 함수 추가

## 바꾼이유
- test 코드에서 nest app을 생성하고 filter, pipe, cookierParser를 적용하는 코드가 반복되서 별도의 함수로 분리

## 설명
- 이메일 인증 후 렌더링 되는 ejs를 로컬 ejs 파일을 읽어서 검증하는 방식
   -  test 코드에서는 ejs를 html 파일로 변환하는 과정이 없기에 ejs 파일을 읽어서 그대로 비교하면 검증이 가능함