### PR TITLE
Feat: 게시글 테스트 보강

### DIFF
--- a/test/e2e/article.e2e-spec.ts
+++ b/test/e2e/article.e2e-spec.ts
@@ -43,6 +43,7 @@ import { FindOneArticleResponseDto } from '@root/article/dto/response/find-one-a
  * HttpStatus.INTERNAL_SERVER_ERROR 쓸것
  * 더미 데이터 어떻게 할지 고민해볼것
  * response dto 가 제대로 확인되고있는지 체크할것
+ * unauthenticated 에러가 잘 나오는지 확인할것
  */
 
 describe('Article', () => {
@@ -125,6 +126,12 @@ describe('Article', () => {
       expect(result.viewCount).toBe(0);
       expect(result.likeCount).toBe(0);
       expect(result.commentCount).toBe(0);
+    });
+
+    test('[실패] POST - unauthorized', async () => {
+      const response = await request(httpServer).post('/articles');
+
+      expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
 
     test('[성공] POST - 글쓰기 권한 높은사람', async () => {
@@ -228,6 +235,12 @@ describe('Article', () => {
       );
     });
 
+    test('[실패] GET - unauthorized', async () => {
+      const response = await request(httpServer).get('/articles');
+
+      expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
+    });
+
     test('[성공] GET - 게시글 목록 조회 권한 높은사람', async () => {
       const findArticleRequestDto = {
         categoryId: categories.free.id,
@@ -318,6 +331,14 @@ describe('Article', () => {
       expect(result.writer.nickname).toBe(users.cadet[0].nickname);
     });
 
+    test('[실패] GET - unauthorized', async () => {
+      const articleId = articles[0].id;
+
+      const response = await request(httpServer).get(`/articles/${articleId}`);
+
+      expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
+    });
+
     test('[성공] GET - 게시글 상세 조회 권한 높은사람', async () => {
       const articleId = articles[0].id;
 
@@ -382,6 +403,14 @@ describe('Article', () => {
       expect(result.content).toBe(updateArticleRequestDto.content);
       expect(result.categoryId).toBe(updateArticleRequestDto.categoryId);
       expect(result.writerId).toBe(users.cadet[0].id);
+    });
+
+    test('[실패] PUT - unauthorized', async () => {
+      const articleId = articles[0].id;
+
+      const response = await request(httpServer).put(`/articles/${articleId}`);
+
+      expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
 
     test('[실패] PUT - 게시글 수정 내가 쓴글이 아닌경우', async () => {
@@ -490,6 +519,16 @@ describe('Article', () => {
 
       const result = await articleRepository.findOne(articleId);
       expect(result).toBeFalsy();
+    });
+
+    test('[실패] DELETE - unauthorized', async () => {
+      const articleId = articles[0].id;
+
+      const response = await request(httpServer).delete(
+        `/articles/${articleId}`,
+      );
+
+      expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
 
     test('[실패] DELETE - 게시글 삭제 내가 쓴글이 아닌경우', async () => {

--- a/test/e2e/article.e2e-spec.ts
+++ b/test/e2e/article.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { getConnection } from 'typeorm';
 import * as cookieParser from 'cookie-parser';
@@ -113,7 +113,7 @@ describe('Article', () => {
         .post('/articles')
         .send(createArticlRequesteDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(201);
+      expect(response.status).toEqual(HttpStatus.CREATED);
 
       const result = response.body as Article;
       expect(result.title).toBe(createArticlRequesteDto.title);
@@ -137,7 +137,7 @@ describe('Article', () => {
         .post('/articles')
         .send(createArticlRequesteDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(201);
+      expect(response.status).toEqual(HttpStatus.CREATED);
     });
 
     test('[실패] POST - 글쓰기 권한 낮은사람', async () => {
@@ -152,7 +152,7 @@ describe('Article', () => {
         .post('/articles')
         .send(createArticlRequesteDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(406);
+      expect(response.status).toEqual(HttpStatus.NOT_ACCEPTABLE);
     });
 
     test('[실패] POST - 글쓰기 존재하지 않는 카테고리', async () => {
@@ -167,7 +167,7 @@ describe('Article', () => {
         .send(createArticlRequesteDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
     });
 
     testDto<CreateArticleRequestDto>([
@@ -192,7 +192,7 @@ describe('Article', () => {
         .send(createArticlRequesteDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
     });
 
     test('[성공] GET - 게시글 목록 조회', async () => {
@@ -204,7 +204,7 @@ describe('Article', () => {
         .get('/articles')
         .query(findArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const responseArticles = response.body.data as Article[];
       expect(responseArticles.length).toBe(2);
@@ -236,7 +236,7 @@ describe('Article', () => {
         .get('/articles')
         .query(findArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
     });
 
     test('[실패] GET - 게시글 목록 조회 권한 낮은사람', async () => {
@@ -249,7 +249,7 @@ describe('Article', () => {
         .get('/articles')
         .query(findArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(406);
+      expect(response.status).toEqual(HttpStatus.NOT_ACCEPTABLE);
     });
 
     test('[실패] GET - 게시글 목록 조희 존재하지 않는 카테고리', async () => {
@@ -262,7 +262,7 @@ describe('Article', () => {
         .query(findArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
     });
 
     testDto<FindAllArticleRequestDto>([
@@ -278,7 +278,7 @@ describe('Article', () => {
         .query(findArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
     });
   });
 
@@ -299,7 +299,7 @@ describe('Article', () => {
       const response = await request(httpServer)
         .get(`/articles/${articleId}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const result = response.body;
       expect(result.title).toBe(articles[0].title);
@@ -323,7 +323,7 @@ describe('Article', () => {
       const response = await request(httpServer)
         .get(`/articles/${articleId}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
     });
 
     test('[실패] GET - 게시글 상세 조회 권한 낮은사람', async () => {
@@ -333,7 +333,7 @@ describe('Article', () => {
       const response = await request(httpServer)
         .get(`/articles/${articleId}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(406);
+      expect(response.status).toEqual(HttpStatus.NOT_ACCEPTABLE);
     });
 
     test('[실패] GET - 게시글 상세 조회 존재하지 않는 게시글', async () => {
@@ -343,7 +343,7 @@ describe('Article', () => {
         .get(`/articles/${articleId}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
     });
 
     testDto<{ articleId: number }>([
@@ -358,7 +358,7 @@ describe('Article', () => {
         .get(`/articles/${articleId}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
     });
 
     test('[성공] PUT - 게시글 수정', async () => {
@@ -373,7 +373,7 @@ describe('Article', () => {
         .put(`/articles/${articleId}`)
         .send(updateArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const result = await articleRepository.findOne(articleId);
       expect(result.title).toBe(updateArticleRequestDto.title);
@@ -394,7 +394,7 @@ describe('Article', () => {
         .put(`/articles/${articleId}`)
         .send(updateArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(404);
+      expect(response.status).toEqual(HttpStatus.NOT_FOUND);
 
       const result = await articleRepository.findOne(articleId);
       expect(result.title).toBe(articles[1].title);
@@ -415,7 +415,7 @@ describe('Article', () => {
         .send(updateArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
     });
 
     test('[실패] PUT - 게시글 수정 존재하지 않는 카테고리', async () => {
@@ -431,7 +431,7 @@ describe('Article', () => {
         .send(updateArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
     });
 
     testDto<{ articleId: number }>([
@@ -452,7 +452,7 @@ describe('Article', () => {
         .send(updateArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
     });
 
     testDto<UpdateArticleRequestDto>([
@@ -475,7 +475,7 @@ describe('Article', () => {
         .send(updateArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
     });
 
     test('[성공] DELETE - 게시글 삭제', async () => {
@@ -484,7 +484,7 @@ describe('Article', () => {
       const response = await request(httpServer)
         .delete(`/articles/${articleId}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
 
       const result = await articleRepository.findOne(articleId);
       expect(result).toBeFalsy();
@@ -496,7 +496,7 @@ describe('Article', () => {
       const response = await request(httpServer)
         .delete(`/articles/${articleId}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(404);
+      expect(response.status).toEqual(HttpStatus.NOT_FOUND);
 
       const result = await articleRepository.findOne(articleId);
       expect(result).toBeTruthy();
@@ -508,7 +508,7 @@ describe('Article', () => {
       const response = await request(httpServer)
         .delete(`/articles/${articleId}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(404);
+      expect(response.status).toEqual(HttpStatus.NOT_FOUND);
 
       const result = await articleRepository.findOne(articleId);
       expect(result).toBeFalsy();
@@ -526,7 +526,7 @@ describe('Article', () => {
         .delete(`/articles/${articleId}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
     });
   });
 });

--- a/test/e2e/article.e2e-spec.ts
+++ b/test/e2e/article.e2e-spec.ts
@@ -278,7 +278,7 @@ describe('Article', () => {
     });
   });
 
-  describe('/articles/:id/comments', () => {
+  describe('/articles/{id}/comments', () => {
     let comments: Comment[];
 
     beforeEach(async () => {
@@ -350,7 +350,7 @@ describe('Article', () => {
     });
   });
 
-  describe('/articles/:id', () => {
+  describe('/articles/{id}', () => {
     beforeEach(async () => {
       users = await dummy.createDummyUsers(userRepository);
       categories = await dummy.createDummyCategories(categoryRepository);

--- a/test/e2e/article.e2e-spec.ts
+++ b/test/e2e/article.e2e-spec.ts
@@ -24,6 +24,8 @@ import { TestBaseModule } from './test.base.module';
 import * as dummy from './utils/dummy';
 import { clearDB, createTestApp } from './utils/utils';
 import { testDto } from './utils/validate-test';
+import { CreateArticleResponseDto } from '@root/article/dto/response/create-article-response.dto';
+import { FindOneArticleResponseDto } from '@root/article/dto/response/find-one-article-response.dto';
 
 /*
 테스트 짜는 순서
@@ -115,7 +117,7 @@ describe('Article', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
       expect(response.status).toEqual(HttpStatus.CREATED);
 
-      const result = response.body as Article;
+      const result = response.body as CreateArticleResponseDto;
       expect(result.title).toBe(createArticlRequesteDto.title);
       expect(result.content).toBe(createArticlRequesteDto.content);
       expect(result.categoryId).toBe(createArticlRequesteDto.categoryId);
@@ -301,7 +303,7 @@ describe('Article', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
       expect(response.status).toEqual(HttpStatus.OK);
 
-      const result = response.body;
+      const result = response.body as FindOneArticleResponseDto;
       expect(result.title).toBe(articles[0].title);
       expect(result.content).toBe(articles[0].content);
       expect(result.categoryId).toBe(articles[0].categoryId);

--- a/test/e2e/article.e2e-spec.ts
+++ b/test/e2e/article.e2e-spec.ts
@@ -1,21 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import { HttpStatus, INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { getConnection } from 'typeorm';
-import * as cookieParser from 'cookie-parser';
 
 import { AuthModule } from '@auth/auth.module';
 import { UserModule } from '@user/user.module';
 import { UserRepository } from '@user/repositories/user.repository';
 import { AuthService } from '@auth/auth.service';
-import { TypeormExceptionFilter } from '@root/filters/typeorm-exception.filter';
 import { ArticleModule } from '@article/article.module';
 import { ArticleRepository } from '@article/repositories/article.repository';
 import { Article } from '@article/entities/article.entity';
 import { CategoryModule } from '@category/category.module';
 import { CategoryRepository } from '@category/repositories/category.repository';
 import { CommentModule } from '@comment/comment.module';
-import { ReactionModule } from '@root/reaction/reaction.module';
 import { CreateArticleRequestDto } from '@root/article/dto/request/create-article-request.dto';
 import { FindAllArticleRequestDto } from '@root/article/dto/request/find-all-article-request.dto';
 import { UpdateArticleRequestDto } from '@root/article/dto/request/update-article-request.dto';
@@ -26,25 +23,6 @@ import { clearDB, createTestApp } from './utils/utils';
 import { testDto } from './utils/validate-test';
 import { CreateArticleResponseDto } from '@root/article/dto/response/create-article-response.dto';
 import { FindOneArticleResponseDto } from '@root/article/dto/response/find-one-article-response.dto';
-
-/*
-테스트 짜는 순서
-1. 정상적인 시나리오대로 성공 케이스 작성
-2. 권한 관련해서 실패 케이스 작성
-3. 400을 제회의한 의도적인 예외처리 관련해서 실패 케이스 작성
-4. dto 에서 날수있는 예외처리 관련해서 실패 케이스 작성
-
-성공 케이스는 응답값 다 잘 있는지 확인할것
-실패 케이스는 상태코드만 확인할것
-*/
-
-/**
- * test module 유틸로 빼기
- * HttpStatus.INTERNAL_SERVER_ERROR 쓸것
- * 더미 데이터 어떻게 할지 고민해볼것
- * response dto 가 제대로 확인되고있는지 체크할것
- * unauthenticated 에러가 잘 나오는지 확인할것
- */
 
 describe('Article', () => {
   let httpServer: INestApplication;
@@ -384,6 +362,7 @@ describe('Article', () => {
       expect(response.status).toBe(HttpStatus.BAD_REQUEST);
     });
 
+    // TODO: novice 도 게시글 수정/삭제 가능한지 추가
     test('[성공] PUT - 게시글 수정', async () => {
       const articleId = articles[0].id;
       const updateArticleRequestDto: UpdateArticleRequestDto = {

--- a/test/e2e/utils/dummy.ts
+++ b/test/e2e/utils/dummy.ts
@@ -6,6 +6,8 @@ import { Comment } from '@comment/entities/comment.entity';
 import { UserRole } from '@root/user/interfaces/userrole.interface';
 import { User } from '@user/entities/user.entity';
 import { ReactionArticle } from '@root/reaction/entities/reaction-article.entity';
+import { UserRepository } from '@root/user/repositories/user.repository';
+import { CategoryRepository } from '@root/category/repositories/category.repository';
 
 export const user = (
   githubUid: string,
@@ -32,9 +34,19 @@ export const jwt = (
   } as JWTPayload);
 };
 
-export const category = (name: string) => {
+export const category = (
+  name: string,
+  commonRole: UserRole = UserRole.CADET,
+  anonymity = false,
+) => {
   const category = new Category();
   category.name = name;
+  category.readableArticle = commonRole;
+  category.writableArticle = commonRole;
+  category.readableComment = commonRole;
+  category.writableComment = commonRole;
+  category.reactionable = commonRole;
+  category.anonymity = anonymity;
   return category;
 };
 
@@ -72,4 +84,66 @@ export const reactionArticle = (
   reactionArticle.articleId = articleId;
   reactionArticle.userId = userId;
   return reactionArticle;
+};
+
+export type DummyUsers = {
+  cadet: User[];
+  admin: User[];
+  novice: User[];
+};
+
+export const createDummyUsers = async (
+  userRepository: UserRepository,
+): Promise<DummyUsers> => {
+  const dummyUsers: DummyUsers = {
+    cadet: await userRepository.save([
+      user('uid1', 'name1', 'githubName1', UserRole.CADET),
+      user('uid2', 'name2', 'githubName2', UserRole.CADET),
+    ]),
+    admin: await userRepository.save([
+      user('uid3', 'name3', 'githubName3', UserRole.ADMIN),
+      user('uid4', 'name4', 'githubName4', UserRole.ADMIN),
+    ]),
+    novice: await userRepository.save([
+      user('uid5', 'name5', 'githubName5', UserRole.NOVICE),
+      user('uid6', 'name6', 'githubName6', UserRole.NOVICE),
+    ]),
+  };
+
+  return dummyUsers;
+};
+
+export type DummyCategories = {
+  free: Category;
+  notice: Category;
+  forall: Category;
+  anony: Category;
+};
+
+export const createDummyCategories = async (
+  categoryRepository: CategoryRepository,
+): Promise<DummyCategories> => {
+  const dummyCategories: DummyCategories = {
+    free: await categoryRepository.save(
+      category('free category', UserRole.CADET),
+    ),
+    notice: await categoryRepository.save(
+      category('notice category', UserRole.ADMIN),
+    ),
+    forall: await categoryRepository.save(
+      category('forall category', UserRole.NOVICE),
+    ),
+    anony: await categoryRepository.save(
+      category('anony category', UserRole.CADET, true),
+    ),
+  };
+
+  return dummyCategories;
+};
+
+export const jwt2 = (user: User, authService: AuthService): string => {
+  return authService.getJWT({
+    userId: user.id,
+    userRole: user.role,
+  } as JWTPayload);
 };

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -1,4 +1,10 @@
 import { getConnection } from 'typeorm';
+import * as cookieParser from 'cookie-parser';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { TestingModule } from '@nestjs/testing';
+
+import { InternalServerErrorExceptionFilter } from '@root/filters/internal-server-error-exception.filter';
+import { TypeormExceptionFilter } from '@root/filters/typeorm-exception.filter';
 
 export const clearDB = async () => {
   const entities = getConnection().entityMetadatas;
@@ -6,4 +12,22 @@ export const clearDB = async () => {
     const repository = getConnection().getRepository(entity.name);
     await repository.query(`TRUNCATE TABLE ${entity.tableName}`);
   }
+};
+
+export const createTestApp = (
+  moduleFixture: TestingModule,
+): INestApplication => {
+  const app = moduleFixture.createNestApplication();
+
+  app.use(cookieParser());
+  app.useGlobalFilters(new InternalServerErrorExceptionFilter());
+  app.useGlobalFilters(new TypeormExceptionFilter());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+  return app;
 };

--- a/test/e2e/utils/validate-test.ts
+++ b/test/e2e/utils/validate-test.ts
@@ -1,109 +1,14 @@
-import * as request from 'supertest';
+export function testDto<T>(testDtos: Array<[keyof T, any, string?]>) {
+  const tests: Array<[string, (normalDto: T) => Partial<T>]> = testDtos.map(
+    ([key, value, detail]) => {
+      const buildDto = (dto: T) => ({
+        ...dto,
+        [key]: value,
+      });
 
-function expectErrorMessage(
-  message: string | string[],
-  response: request.Response,
-) {
-  if (message instanceof Array) {
-    expect(response.body.message).toEqual(expect.arrayContaining(message));
-  } else {
-    expect(response.body.message).toEqual(message);
-  }
-}
+      return [`${key} 값이 ${detail ?? value}`, buildDto];
+    },
+  );
 
-export class ValidateTester<T> {
-  constructor(
-    public readonly testName: string,
-    public readonly buildDto: (normalDto: T) => Partial<T>,
-    public readonly expectErrorResponse: (response: request.Response) => void,
-  ) {}
-}
-
-export function buildValidateTest<T>(
-  key: keyof T,
-  buildTests: Array<<T>(key: keyof T) => ValidateTester<T>>,
-): Array<[string, ValidateTester<T>]> {
-  return buildTests.map((buildTest) => {
-    const test: ValidateTester<T> = buildTest<T>(key);
-
-    return [`${test.testName}`, test];
-  });
-}
-
-export function 값이_없는_경우(param?: {
-  message: string | string[];
-}): <T>(key: keyof T) => ValidateTester<T> {
-  return <T>(key: keyof T) => {
-    const name = `${key} 값이 없을 때`;
-    const buildDto = (dto: T) => ({
-      ...dto,
-      [key]: undefined,
-    });
-    const expectErrorResponse = (response: request.Response) => {
-      expect(response.status).toBe(400);
-      if (param) {
-        expectErrorMessage(param.message, response);
-      } else {
-        expectErrorMessage([`${key} should not be empty`], response);
-      }
-    };
-
-    return new ValidateTester<T>(name, buildDto, expectErrorResponse);
-  };
-}
-
-export function 잘못된_값을_입력한_경우(param: {
-  detail: string;
-  wrongValue: any;
-  message: string | string[];
-}): <T>(key: keyof T) => ValidateTester<T> {
-  return <T>(key: keyof T) => {
-    const testName = `${key} 값이 ${param.detail} 일 때`;
-    const buildDto = (dto: T) => ({
-      ...dto,
-      [key]: param.wrongValue,
-    });
-    const expectErrorResponse = (response: request.Response) => {
-      expect(response.status).toBe(400);
-      expectErrorMessage(param.message, response);
-    };
-
-    return new ValidateTester(testName, buildDto, expectErrorResponse);
-  };
-}
-
-export function 타입이_틀린_경우(param: {
-  wrongValue: any;
-  message: string | string[];
-}): <T>(key: keyof T) => ValidateTester<T> {
-  return <T>(key: keyof T) => {
-    const testName = `${key} 타입이 틀렸을때 (${param.wrongValue} 입력됨)`;
-    const buildDto = (dto: T) => ({
-      ...dto,
-      [key]: param.wrongValue,
-    });
-    const expectErrorResponse = (response: request.Response) => {
-      expect(response.status).toBe(400);
-      expectErrorMessage(param.message, response);
-    };
-
-    return new ValidateTester(testName, buildDto, expectErrorResponse);
-  };
-}
-
-export function 엔티티가_없는_경우(param: {
-  notExistEntityId: number;
-}): <T>(key: keyof T) => ValidateTester<T> {
-  return <T>(key: keyof T) => {
-    const testName = `${key} 엔티티가 없는 경우 (${param.notExistEntityId} 입력됨)`;
-    const buildDto = (dto: T) => ({
-      ...dto,
-      [key]: param.notExistEntityId,
-    });
-    const expectErrorResponse = (response: request.Response) => {
-      expect(response.status).toBe(404);
-    };
-
-    return new ValidateTester(testName, buildDto, expectErrorResponse);
-  };
+  return test.each(tests);
 }


### PR DESCRIPTION
## 바뀐점
기존에 복잡하던 validate 테스트를 함수 하나로 줄임
게시글에서 확인해야하는 케이스 확인
기존 jwt 함수를 보완한  jwt2 함수 추가됨 -> 추후에 이걸로 바꿨으면 좋겠어요

## 설명
테스트 짜는 순서
1. 정상적인 시나리오대로 성공 케이스 작성
2. 권한 관련해서 실패 케이스 작성
3. 400을 제회의한 의도적인 예외처리 관련해서 실패 케이스 작성
4. dto 에서 날수있는 예외처리 관련해서 실패 케이스 작성

성공 케이스는 응답값 다 잘 있는지 확인할것
실패 케이스는 상태코드만 확인할것

/**
 * test module 유틸로 빼기
 * HttpStatus.INTERNAL_SERVER_ERROR 쓸것
 * 더미 데이터 어떻게 할지 고민해볼것
 * response dto 가 제대로 확인되고있는지 체크할것
 * unauthenticated 에러가 잘 나오는지 확인할것
 * :id 말고 {id} 쓸것
 * join 되는 엔티티는 join 이 잘되어있는지 속성 잘 확인할것
 * 필요한 더미 데이터 정의는 describe 안에서 할것
 */