### PR TITLE
Feat: 카테고리 테스트 케이스 추가

### DIFF
--- a/test/e2e/category.e2e-spec.ts
+++ b/test/e2e/category.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import * as cookieParser from 'cookie-parser';
 
@@ -21,14 +21,17 @@ import { User } from '@root/user/entities/user.entity';
 import { Category } from '@root/category/entities/category.entity';
 import { CreateCategoryRequestDto } from '@root/category/dto/request/create-category-request.dto';
 import { CategoryResponseDto } from '@root/category/dto/response/category-response.dto';
+import { CategoryRepository } from '@root/category/repositories/category.repository';
 
 describe('Category', () => {
   let app: INestApplication;
   let userRepository: UserRepository;
+  let categoryRepository: CategoryRepository;
   let authService: AuthService;
   let JWT;
   let dummyUsers: User[] = [];
-  let dummyCategories: Category[];
+  let dummyCategories: Category[] = [];
+  let server: INestApplication;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -49,63 +52,211 @@ describe('Category', () => {
     );
     await app.init();
 
-    userRepository = moduleFixture.get<UserRepository>(UserRepository);
-    authService = moduleFixture.get<AuthService>(AuthService);
+    userRepository = moduleFixture.get(UserRepository);
+    categoryRepository = moduleFixture.get(CategoryRepository);
+    authService = moduleFixture.get(AuthService);
 
-    app = app.getHttpServer();
+    server = app.getHttpServer();
   });
 
   afterAll(async () => {
     await getConnection().dropDatabase();
     await getConnection().close();
-    await app.close();
+    await server.close();
   });
 
   describe('/categories', () => {
-    dummyUsers.push(
-      dummy.user('test1234', 'first user', 'githubUsername', UserRole.CADET),
-    );
-    dummyUsers.push(
-      dummy.user('test1234', 'second user', 'githubUsername2', UserRole.ADMIN),
-    );
+    dummyUsers.push(dummy.user('admin', 'admin', 'admin', UserRole.ADMIN));
+    dummyUsers.push(dummy.user('cadet', 'cadet', 'cadet', UserRole.CADET));
+    dummyUsers.push(dummy.user('novice', 'novice', 'novice', UserRole.NOVICE));
 
+    dummyCategories.push(dummy.category('자유게시판'));
+    dummyCategories.push(dummy.category('익명게시판'));
+    dummyCategories.push(dummy.category('유머게시판'));
     beforeEach(async () => {
       await userRepository.save(dummyUsers);
-
-      // JWT = dummy.jwt(dummyUsers[1].id, dummyUsers[1].role, authService);
+      await categoryRepository.save(dummyCategories);
     });
 
     afterEach(async () => {
       await clearDB();
     });
 
-    test('[성공] POST - 카테고리 생성', async () => {
-      const jwt = dummy.jwt(dummyUsers[1].id, dummyUsers[1].role, authService);
+    test('[성공] POST - ADMIN이 카테고리 생성', async () => {
+      const jwt = dummy.jwt(dummyUsers[0].id, dummyUsers[0].role, authService);
       const createCategoryRequestDto: CreateCategoryRequestDto = {
-        name: 'hello',
+        name: 'new_category',
       };
-      const response = await request(app)
+      const response = await request(server)
         .post('/categories')
         .send(createCategoryRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
-      expect(response.status).toEqual(201);
+      expect(response.status).toEqual(HttpStatus.CREATED);
 
-      const result = response.body as CategoryResponseDto;
+      const catetory = response.body as CategoryResponseDto;
 
-      expect(result.id).toBeDefined();
-      expect(result.name).toBe('hello');
-      expect(result.isArticleWritable).toBe(true);
-      expect(result.isArticleReadable).toBe(true);
-      expect(result.isCommentWritable).toBe(true);
-      expect(result.isCommentReadable).toBe(true);
-      expect(result.isReactionable).toBe(true);
-      expect(result.isAnonymous).toBe(false);
+      expect(catetory.id).toBeDefined();
+      expect(catetory.name).toBe('new_category');
+      expect(catetory.isArticleWritable).toBe(true);
+      expect(catetory.isArticleReadable).toBe(true);
+      expect(catetory.isCommentWritable).toBe(true);
+      expect(catetory.isCommentReadable).toBe(true);
+      expect(catetory.isReactionable).toBe(true);
+      expect(catetory.isAnonymous).toBe(false);
     });
 
-    // test('[실패] POST - unauthorized', async () => {
-    //   const response = await request(app).post('/image');
+    test('[실패] POST - CADET이 카테고리 생성', async () => {
+      const jwt = dummy.jwt(dummyUsers[1].id, dummyUsers[1].role, authService);
+      const createCategoryRequestDto: CreateCategoryRequestDto = {
+        name: 'new_category',
+      };
+      const response = await request(server)
+        .post('/categories')
+        .send(createCategoryRequestDto)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
+      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
+    });
 
-    //   expect(response.status).toEqual(401);
-    // });
+    test('[실패] POST - NOVICE가 카테고리 생성', async () => {
+      const jwt = dummy.jwt(dummyUsers[2].id, dummyUsers[2].role, authService);
+      const createCategoryRequestDto: CreateCategoryRequestDto = {
+        name: 'new_category',
+      };
+      const response = await request(server)
+        .post('/categories')
+        .send(createCategoryRequestDto)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
+      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
+    });
+
+    test('[실패] POST - unauthorized', async () => {
+      const response = await request(server).post('/categories');
+
+      expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
+    });
+
+    test('[성공] GET - ADMIN이 카테고리 종류 가져오기', async () => {
+      const jwt = dummy.jwt(dummyUsers[0].id, dummyUsers[0].role, authService);
+
+      const response = await request(server)
+        .get('/categories')
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
+      expect(response.status).toEqual(HttpStatus.OK);
+
+      const categories = response.body as CategoryResponseDto[];
+
+      expect(categories).toBeInstanceOf(Array);
+      expect(categories[0].name).toBe('자유게시판');
+      expect(categories[1].name).toBe('익명게시판');
+      expect(categories[2].name).toBe('유머게시판');
+    });
+
+    test('[성공] GET - CADET이 카테고리 종류 가져오기', async () => {
+      const jwt = dummy.jwt(dummyUsers[1].id, dummyUsers[1].role, authService);
+
+      const response = await request(server)
+        .get('/categories')
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
+      expect(response.status).toEqual(HttpStatus.OK);
+
+      const categories = response.body as CategoryResponseDto[];
+
+      expect(categories).toBeInstanceOf(Array);
+      expect(categories[0].name).toBe('자유게시판');
+      expect(categories[1].name).toBe('익명게시판');
+      expect(categories[2].name).toBe('유머게시판');
+    });
+
+    test('[실패] GET - NOVICE가 카테고리 종류 가져오기', async () => {
+      const jwt = dummy.jwt(dummyUsers[2].id, dummyUsers[2].role, authService);
+
+      const response = await request(server)
+        .get('/categories')
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
+      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
+    });
+
+    test('[실패] GET - unauthorized', async () => {
+      const response = await request(server).get('/categories');
+
+      expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
+    });
+
+    test('[성공] PUT - ADMIN이 카테고리 이름 수정', async () => {
+      const jwt = dummy.jwt(dummyUsers[0].id, dummyUsers[0].role, authService);
+      const createCategoryRequestDto: CreateCategoryRequestDto = {
+        name: 'update_category',
+      };
+      const id = 2;
+      const response = await request(server)
+        .put(`/categories/${id}/name`)
+        .send(createCategoryRequestDto)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
+      expect(response.status).toEqual(HttpStatus.OK);
+
+      const category = response.body as CategoryResponseDto;
+
+      expect(category.id).toBe(2);
+      expect(category.name).toBe('update_category');
+    });
+
+    test('[실패] PUT - CADET이 카테고리 이름 수정', async () => {
+      const jwt = dummy.jwt(dummyUsers[1].id, dummyUsers[1].role, authService);
+      const id = 2;
+      const response = await request(server)
+        .put(`/categories/${id}/name`)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
+      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
+    });
+
+    test('[실패] PUT - NOVICE가 카테고리 이름 수정', async () => {
+      const jwt = dummy.jwt(dummyUsers[2].id, dummyUsers[2].role, authService);
+      const id = 2;
+      const response = await request(server)
+        .put(`/categories/${id}/name`)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
+      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
+    });
+
+    test('[실패] PUT - unauthorized', async () => {
+      const id = 1;
+      const response = await request(server).put(`/categories/${id}/name`);
+
+      expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
+    });
+
+    test('[성공] DELETE - ADMIN이 카테고리 삭제', async () => {
+      const jwt = dummy.jwt(dummyUsers[0].id, dummyUsers[0].role, authService);
+      const id = 1;
+      const response = await request(server)
+        .delete(`/categories/${id}`)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
+      expect(response.status).toEqual(HttpStatus.OK);
+    });
+
+    test('[실패] DELETE - CADET이 카테고리 삭제', async () => {
+      const jwt = dummy.jwt(dummyUsers[1].id, dummyUsers[1].role, authService);
+      const id = 1;
+      const response = await request(server)
+        .delete(`/categories/${id}`)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
+      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
+    });
+
+    test('[실패] DELETE - NOVICE가 카테고리 삭제', async () => {
+      const jwt = dummy.jwt(dummyUsers[2].id, dummyUsers[2].role, authService);
+      const id = 1;
+      const response = await request(server)
+        .delete(`/categories/${id}`)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
+      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
+    });
+
+    test('[실패] DELETE - unauthorized', async () => {
+      const id = 1;
+      const response = await request(server).delete(`/categories/${id}`);
+
+      expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
+    });
   });
 });

--- a/test/e2e/category.e2e-spec.ts
+++ b/test/e2e/category.e2e-spec.ts
@@ -57,6 +57,14 @@ describe('Category', () => {
     authService = moduleFixture.get(AuthService);
 
     server = app.getHttpServer();
+
+    dummyUsers.push(dummy.user('admin', 'admin', 'admin', UserRole.ADMIN));
+    dummyUsers.push(dummy.user('cadet', 'cadet', 'cadet', UserRole.CADET));
+    dummyUsers.push(dummy.user('novice', 'novice', 'novice', UserRole.NOVICE));
+
+    dummyCategories.push(dummy.category('자유게시판'));
+    dummyCategories.push(dummy.category('익명게시판'));
+    dummyCategories.push(dummy.category('유머게시판'));
   });
 
   afterAll(async () => {
@@ -66,13 +74,6 @@ describe('Category', () => {
   });
 
   describe('/categories', () => {
-    dummyUsers.push(dummy.user('admin', 'admin', 'admin', UserRole.ADMIN));
-    dummyUsers.push(dummy.user('cadet', 'cadet', 'cadet', UserRole.CADET));
-    dummyUsers.push(dummy.user('novice', 'novice', 'novice', UserRole.NOVICE));
-
-    dummyCategories.push(dummy.category('자유게시판'));
-    dummyCategories.push(dummy.category('익명게시판'));
-    dummyCategories.push(dummy.category('유머게시판'));
     beforeEach(async () => {
       await userRepository.save(dummyUsers);
       await categoryRepository.save(dummyCategories);
@@ -181,6 +182,17 @@ describe('Category', () => {
 
       expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
+  });
+
+  describe('/categories/{id}/name', () => {
+    beforeEach(async () => {
+      await userRepository.save(dummyUsers);
+      await categoryRepository.save(dummyCategories);
+    });
+
+    afterEach(async () => {
+      await clearDB();
+    });
 
     test('[성공] PUT - ADMIN이 카테고리 이름 수정', async () => {
       const jwt = dummy.jwt(dummyUsers[0].id, dummyUsers[0].role, authService);
@@ -223,6 +235,17 @@ describe('Category', () => {
       const response = await request(server).put(`/categories/${id}/name`);
 
       expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
+    });
+  });
+
+  describe('/categories/{id}', () => {
+    beforeEach(async () => {
+      await userRepository.save(dummyUsers);
+      await categoryRepository.save(dummyCategories);
+    });
+
+    afterEach(async () => {
+      await clearDB();
     });
 
     test('[성공] DELETE - ADMIN이 카테고리 삭제', async () => {

--- a/test/e2e/category.e2e-spec.ts
+++ b/test/e2e/category.e2e-spec.ts
@@ -1,0 +1,111 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import * as cookieParser from 'cookie-parser';
+
+import { UserRepository } from '@user/repositories/user.repository';
+import { AuthService } from '@auth/auth.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserModule } from '@user/user.module';
+import { AuthModule } from '@auth/auth.module';
+import { TypeormExceptionFilter } from '@root/filters/typeorm-exception.filter';
+import { ImageModule } from '@image/image.module';
+import { getConnection } from 'typeorm';
+import { UploadImageUrlResponseDto } from '@image/dto/upload-image-url-response.dto';
+import { TestBaseModule } from '@test/e2e/test.base.module';
+import { clearDB } from '@test/e2e/utils/utils';
+import * as dummy from './utils/dummy';
+import { UserRole } from '@root/user/interfaces/userrole.interface';
+import { InternalServerErrorExceptionFilter } from '@root/filters/internal-server-error-exception.filter';
+import { CategoryModule } from '@root/category/category.module';
+import { User } from '@root/user/entities/user.entity';
+import { Category } from '@root/category/entities/category.entity';
+import { CreateCategoryRequestDto } from '@root/category/dto/request/create-category-request.dto';
+import { CategoryResponseDto } from '@root/category/dto/response/category-response.dto';
+
+describe('Category', () => {
+  let app: INestApplication;
+  let userRepository: UserRepository;
+  let authService: AuthService;
+  let JWT;
+  let dummyUsers: User[] = [];
+  let dummyCategories: Category[];
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestBaseModule, UserModule, AuthModule, CategoryModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.use(cookieParser());
+
+    app.useGlobalFilters(new InternalServerErrorExceptionFilter());
+    app.useGlobalFilters(new TypeormExceptionFilter());
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+
+    userRepository = moduleFixture.get<UserRepository>(UserRepository);
+    authService = moduleFixture.get<AuthService>(AuthService);
+
+    app = app.getHttpServer();
+  });
+
+  afterAll(async () => {
+    await getConnection().dropDatabase();
+    await getConnection().close();
+    await app.close();
+  });
+
+  describe('/categories', () => {
+    dummyUsers.push(
+      dummy.user('test1234', 'first user', 'githubUsername', UserRole.CADET),
+    );
+    dummyUsers.push(
+      dummy.user('test1234', 'second user', 'githubUsername2', UserRole.ADMIN),
+    );
+
+    beforeEach(async () => {
+      await userRepository.save(dummyUsers);
+
+      // JWT = dummy.jwt(dummyUsers[1].id, dummyUsers[1].role, authService);
+    });
+
+    afterEach(async () => {
+      await clearDB();
+    });
+
+    test('[성공] POST - 카테고리 생성', async () => {
+      const jwt = dummy.jwt(dummyUsers[1].id, dummyUsers[1].role, authService);
+      const createCategoryRequestDto: CreateCategoryRequestDto = {
+        name: 'hello',
+      };
+      const response = await request(app)
+        .post('/categories')
+        .send(createCategoryRequestDto)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt}`);
+      expect(response.status).toEqual(201);
+
+      const result = response.body as CategoryResponseDto;
+
+      expect(result.id).toBeDefined();
+      expect(result.name).toBe('hello');
+      expect(result.isArticleWritable).toBe(true);
+      expect(result.isArticleReadable).toBe(true);
+      expect(result.isCommentWritable).toBe(true);
+      expect(result.isCommentReadable).toBe(true);
+      expect(result.isReactionable).toBe(true);
+      expect(result.isAnonymous).toBe(false);
+    });
+
+    // test('[실패] POST - unauthorized', async () => {
+    //   const response = await request(app).post('/image');
+
+    //   expect(response.status).toEqual(401);
+    // });
+  });
+});

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -1,4 +1,10 @@
 import { getConnection } from 'typeorm';
+import * as cookieParser from 'cookie-parser';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { TestingModule } from '@nestjs/testing';
+
+import { InternalServerErrorExceptionFilter } from '@root/filters/internal-server-error-exception.filter';
+import { TypeormExceptionFilter } from '@root/filters/typeorm-exception.filter';
 
 export const clearDB = async () => {
   const entities = getConnection().entityMetadatas;
@@ -6,4 +12,22 @@ export const clearDB = async () => {
     const repository = getConnection().getRepository(entity.name);
     await repository.query(`TRUNCATE TABLE ${entity.tableName}`);
   }
+};
+
+export const createTestApp = (
+  moduleFixture: TestingModule,
+): INestApplication => {
+  const app = moduleFixture.createNestApplication();
+
+  app.use(cookieParser());
+  app.useGlobalFilters(new InternalServerErrorExceptionFilter());
+  app.useGlobalFilters(new TypeormExceptionFilter());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+  return app;
 };


### PR DESCRIPTION
## 바뀐점
- category API 테스트 케이스를 추가 하였습니다.
## 바꾼이유
- 디렉토리 변경을 위한 테스트코드가 필요했습니다.
## 설명
- user와 category를 배열로 구성하였습니다.
- user더미는 0번이 admin, 1번이 cadet, 2번이 novice 입니다.
- 모든 테스트는 admin, cadet, novice로 나누어 진행하였습니다.
- 카테고리 종류를 가져오는 부분은 배열형태인지 확인 후 각 요소의 이름을 확인하였습니다.
-----------------------------------------------------
추가
- createTestApp util 합병하였습니다.
- users 객체로 변경하였습니다. (admin, cadet, novice)
- category 객체로 변경하였습니다. (자유게시판, 익명게시판, 유머게시판)
- jwt 객체로 변경하였습니다. (admin, cadet, novice)
- 파라미터 id값 beforeEach에서 재사용하였습니다.

-----------------------------------------------------------

- /categories [성공] POST - ADMIN이 카테고리 생성
- /categories [실패] POST - CADET이 카테고리 생성
- /categories [실패] POST - NOVICE가 카테고리 생성
- /categories [실패] POST - unauthorized

- /categories [성공] GET - ADMIN이 카테고리 종류 가져오기
- /categories [성공] GET - CADET이 카테고리 종류 가져오기
- /categories [실패] GET - NOVICE가 카테고리 종류 가져오기
- /categories [실패] GET - unauthorized

- /categories/{id}/name [성공] PUT - ADMIN이 카테고리 이름 수정
- /categories/{id}/name [실패] PUT - CADET이 카테고리 이름 수정
- /categories/{id}/name [실패] PUT - NOVICE가 카테고리 이름 수정
- /categories/{id}/name [실패] PUT - unauthorized

- /categories/{id} [성공] DELETE - ADMIN이 카테고리 삭제
- /categories/{id} [실패] DELETE - CADET이 카테고리 삭제
- /categories/{id} [실패] DELETE - NOVICE가 카테고리 삭제
- /categories/{id} [실패] DELETE - unauthorized