### PR TITLE
Fix: post response 응답코드 swagger 명세 수정

### DIFF
--- a/src/article/article.controller.ts
+++ b/src/article/article.controller.ts
@@ -19,6 +19,7 @@ import { AlsoNovice, GetUser } from '@root/auth/auth.decorator';
 import { CommentService } from '@root/comment/comment.service';
 import {
   ApiCookieAuth,
+  ApiCreatedResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -54,7 +55,7 @@ export class ArticleController {
   @Post()
   @AlsoNovice()
   @ApiOperation({ summary: '게시글 업로드' })
-  @ApiOkResponse({
+  @ApiCreatedResponse({
     description: '업로드된 게시글',
     type: CreateArticleResponseDto,
   })

--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import {
   ApiCookieAuth,
+  ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -33,7 +34,7 @@ export class CategoryController {
   @Post()
   @Admin()
   @ApiOperation({ summary: '카테고리 생성하기 (관리자)' })
-  @ApiOkResponse({ description: '카테고리', type: CategoryResponseDto })
+  @ApiCreatedResponse({ description: '카테고리', type: CategoryResponseDto })
   @ApiForbiddenResponse({ description: '접근 권한 없음' })
   async create(
     @GetUser() user: User,

--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common';
 import {
   ApiCookieAuth,
+  ApiCreatedResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -31,7 +32,7 @@ export class CommentController {
 
   @Post()
   @ApiOperation({ summary: '댓글 생성' })
-  @ApiOkResponse({ description: '생성된 댓글', type: CreateCommentRequestDto })
+  @ApiCreatedResponse({ description: '생성된 댓글', type: CreateCommentRequestDto })
   @ApiNotFoundResponse({ description: '존재하지 않는 게시글' })
   async create(
     @GetUser() writer: User,

--- a/src/image/image.controller.ts
+++ b/src/image/image.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Post } from '@nestjs/common';
 import {
   ApiCookieAuth,
-  ApiOkResponse,
+  ApiCreatedResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
@@ -18,7 +18,7 @@ export class ImageController {
 
   @Post()
   @ApiOperation({ summary: '이미지 업로드 URL 생성' })
-  @ApiOkResponse({
+  @ApiCreatedResponse({
     description: '생성된 업로드 URL',
     type: UploadImageUrlResponseDto,
   })

--- a/src/reaction/reaction.controller.ts
+++ b/src/reaction/reaction.controller.ts
@@ -1,8 +1,8 @@
 import { Controller, Post, Param, ParseIntPipe } from '@nestjs/common';
 import {
   ApiCookieAuth,
+  ApiCreatedResponse,
   ApiNotFoundResponse,
-  ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
@@ -22,7 +22,7 @@ export class ReactionController {
 
   @Post('articles/:id')
   @ApiOperation({ summary: '게시글 좋아요 버튼' })
-  @ApiOkResponse({
+  @ApiCreatedResponse({
     description: '게시글 좋아요 버튼 누름',
     type: ReactionResponseDto,
   })
@@ -39,7 +39,7 @@ export class ReactionController {
 
   @Post('articles/:articleId/comments/:commentId')
   @ApiOperation({ summary: '댓글 좋아요 버튼' })
-  @ApiOkResponse({
+  @ApiCreatedResponse({
     description: '댓글 좋아요 버튼 누름',
     type: ReactionResponseDto,
   })


### PR DESCRIPTION
## 바뀐점
ApiOkResponse로 명세된 POST 응답들의 명세를 ApiCreatedResponse로 수정

## 바꾼이유
#162 /intra-auth 뿐만아닌 post 요청에서 201 응답이 날아오는 부분에 관한 명세를 알맞게 수정

## 설명
POST /intra-auth의 경우에는 상의 후 201로 명세를 표기 할 지 응답코드를 수정할지 결정
