### PR TITLE
Chore: eslint configRootDir 절대경로로 지정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   parserOptions: {
     project: 'tsconfig.json',
     sourceType: 'module',
+	tsconfigRootDir: __dirname,
   },
   plugins: ['@typescript-eslint/eslint-plugin'],
   extends: [


### PR DESCRIPTION
## 바뀐점
eslint의 tsconfig파일을 찾는 경로를 workspace/ 에서 __dirname/ 으로 변경

## 바꾼이유
vscode workspace를 42world-Backend로 열지 않으면 모든 ts파일에서 tsconfig 경로가 달라 인식을 못함

## 설명
https://haeunyah.tistory.com/m/123
