### PR TITLE
Feature: 응답 httpcode를 201에서 200으로 나오게 변경

### DIFF
--- a/src/image/image.controller.ts
+++ b/src/image/image.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post } from '@nestjs/common';
+import { Controller, HttpCode, Post } from '@nestjs/common';
 import {
   ApiCookieAuth,
   ApiOkResponse,
@@ -17,6 +17,7 @@ export class ImageController {
   constructor(private readonly imageService: ImageService) {}
 
   @Post()
+  @HttpCode(200)
   @ApiOperation({ summary: '이미지 업로드 URL 생성' })
   @ApiOkResponse({
     description: '생성된 업로드 URL',

--- a/src/intra-auth/intra-auth.controller.ts
+++ b/src/intra-auth/intra-auth.controller.ts
@@ -6,6 +6,7 @@ import {
   Query,
   Render,
   UseFilters,
+  HttpCode,
 } from '@nestjs/common';
 import {
   ApiCookieAuth,
@@ -28,6 +29,7 @@ export class IntraAuthController {
   constructor(private readonly intraAuthService: IntraAuthService) {}
 
   @Post()
+  @HttpCode(200)
   @OnlyNovice()
   @ApiCookieAuth()
   @UseFilters(AllExceptionsFilter)

--- a/src/reaction/reaction.controller.ts
+++ b/src/reaction/reaction.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Post, Param, ParseIntPipe } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Param,
+  ParseIntPipe,
+  HttpCode,
+} from '@nestjs/common';
 import {
   ApiCookieAuth,
   ApiNotFoundResponse,
@@ -21,6 +27,7 @@ export class ReactionController {
   constructor(private readonly reactionService: ReactionService) {}
 
   @Post('articles/:id')
+  @HttpCode(200)
   @ApiOperation({ summary: '게시글 좋아요 버튼' })
   @ApiOkResponse({
     description: '게시글 좋아요 버튼 누름',
@@ -38,6 +45,7 @@ export class ReactionController {
   }
 
   @Post('articles/:articleId/comments/:commentId')
+  @HttpCode(200)
   @ApiOperation({ summary: '댓글 좋아요 버튼' })
   @ApiOkResponse({
     description: '댓글 좋아요 버튼 누름',

--- a/test/e2e/image.e2e-spec.ts
+++ b/test/e2e/image.e2e-spec.ts
@@ -78,7 +78,7 @@ describe('Image', () => {
 
       const result = response.body as UploadImageUrlResponseDto;
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toEqual(200);
       expect(result.uploadUrl).toBeTruthy();
     });
 

--- a/test/e2e/image.e2e-spec.ts
+++ b/test/e2e/image.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { INestApplication, ValidationPipe, HttpStatus } from '@nestjs/common';
 import * as request from 'supertest';
 import * as cookieParser from 'cookie-parser';
 
@@ -78,7 +78,7 @@ describe('Image', () => {
 
       const result = response.body as UploadImageUrlResponseDto;
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
       expect(result.uploadUrl).toBeTruthy();
     });
 

--- a/test/e2e/image.e2e-spec.ts
+++ b/test/e2e/image.e2e-spec.ts
@@ -85,7 +85,7 @@ describe('Image', () => {
     test('[실패] POST - unauthorized', async () => {
       const response = await request(app).post('/image');
 
-      expect(response.status).toEqual(401);
+      expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
   });
 });

--- a/test/e2e/intra-auth.e2e-spec.ts
+++ b/test/e2e/intra-auth.e2e-spec.ts
@@ -110,7 +110,7 @@ describe('IntraAuth', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`)
         .send({ intraId });
 
-      expect(response.status).toEqual(HttpStatus.CREATED);
+      expect(response.status).toEqual(HttpStatus.OK);
     });
 
     test('[실패] POST - user role이 NOVICE가 아닌 경우', async () => {

--- a/test/e2e/reaction.e2e-spec.ts
+++ b/test/e2e/reaction.e2e-spec.ts
@@ -6,7 +6,7 @@ import { CategoryModule } from '@category/category.module';
 import { CategoryRepository } from '@category/repositories/category.repository';
 import { CommentModule } from '@comment/comment.module';
 import { CommentRepository } from '@comment/repositories/comment.repository';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { INestApplication, ValidationPipe, HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeormExceptionFilter } from '@root/filters/typeorm-exception.filter';
 import { ReactionModule } from '@root/reaction/reaction.module';
@@ -102,7 +102,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/1')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
       expect(response.body.isLike).toEqual(true);
       expect(response.body.likeCount).toEqual(1);
     });
@@ -116,7 +116,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/1')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response2.status).toEqual(200);
+      expect(response2.status).toEqual(HttpStatus.OK);
       expect(response2.body.isLike).toEqual(false);
       expect(response2.body.likeCount).toEqual(0);
     });
@@ -161,7 +161,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/1/comments/1')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(HttpStatus.OK);
       expect(response.body.isLike).toEqual(true);
       expect(response.body.likeCount).toEqual(1);
     });
@@ -175,7 +175,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/1/comments/1')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response2.status).toEqual(200);
+      expect(response2.status).toEqual(HttpStatus.OK);
       expect(response2.body.isLike).toEqual(false);
       expect(response2.body.likeCount).toEqual(0);
     });
@@ -195,7 +195,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/' + notExistId + '/comments/1')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(200); // TODO - 코드가 이상하다 200을 돌려준다
+      expect(response.status).toEqual(HttpStatus.OK); // TODO - 코드가 이상하다 HttpStatus.OK을 돌려준다
     });
 
     test('[실패] POST - 없는 commentId를 보내는 경우', async () => {

--- a/test/e2e/reaction.e2e-spec.ts
+++ b/test/e2e/reaction.e2e-spec.ts
@@ -124,7 +124,7 @@ describe('Reaction', () => {
     test('[실패] POST - unauthorize', async () => {
       const response = await request(app).post('/reactions/articles/1');
 
-      expect(response.status).toEqual(401);
+      expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
 
     test('[실패] POST - 없는 id를 보내는 경우', async () => {
@@ -134,7 +134,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/' + notExistId)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toEqual(HttpStatus.NOT_FOUND);
     });
   });
 
@@ -185,7 +185,7 @@ describe('Reaction', () => {
         '/reactions/articles/1/comments/1',
       );
 
-      expect(response.status).toEqual(401);
+      expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
 
     test('[실패] POST - 없는 articleId를 보내는 경우', async () => {
@@ -205,7 +205,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/1/comments/' + notExistId)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toEqual(HttpStatus.NOT_FOUND);
     });
   });
 });

--- a/test/e2e/reaction.e2e-spec.ts
+++ b/test/e2e/reaction.e2e-spec.ts
@@ -102,7 +102,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/1')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toEqual(200);
       expect(response.body.isLike).toEqual(true);
       expect(response.body.likeCount).toEqual(1);
     });
@@ -116,7 +116,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/1')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response2.status).toEqual(201);
+      expect(response2.status).toEqual(200);
       expect(response2.body.isLike).toEqual(false);
       expect(response2.body.likeCount).toEqual(0);
     });
@@ -161,7 +161,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/1/comments/1')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toEqual(200);
       expect(response.body.isLike).toEqual(true);
       expect(response.body.likeCount).toEqual(1);
     });
@@ -175,7 +175,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/1/comments/1')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response2.status).toEqual(201);
+      expect(response2.status).toEqual(200);
       expect(response2.body.isLike).toEqual(false);
       expect(response2.body.likeCount).toEqual(0);
     });
@@ -195,7 +195,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/' + notExistId + '/comments/1')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(201); // TODO - 코드가 이상하다 201을 돌려준다
+      expect(response.status).toEqual(200); // TODO - 코드가 이상하다 200을 돌려준다
     });
 
     test('[실패] POST - 없는 commentId를 보내는 경우', async () => {


### PR DESCRIPTION
## 바뀐점
intra-auth
image
reation
에 대해서 POST 요청의 http응답코드가 201이였던걸 200으로 변경하였습니다.

## 바꾼이유
POST이지만, 의미상 유의미한 리소스가 생성되는 api요청은 아니기때문에 200으로 하였습니다.

## 설명
근데 조금 애매하긴하네요.. 그냥 201로 둬도 될거같기도하고... 
특히 reation은 버튼을 누를때마다 리액션이 생성되기도 하고 없어지기도 해서 그냥 PUT으로 바꾸는게 좀더 맞는거같다는 생각이 드네요
