### PR TITLE
Refactor: Cache Module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 
 dev:
 	cp ./config/.env.dev ./config/.env
-	make db redis
+	make db
 	yarn start:dev
 
 alpha:
@@ -28,17 +28,6 @@ db: db-dev
 
 db-down:
 	${COMPOSE} down db
-
-redis: redis-dev
-
-redis-down:
-	${COMPOSE} down redis
-
-redis-dev:
-	export NODE_ENV=dev && $(call COMPOSE_ENV) up --build -d redis
-
-redis-alpha:
-	export NODE_ENV=alpha && sudo $(call COMPOSE_ENV) up --build -d redis
 
 api:
 	api-dev

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 dev:
 	cp ./config/.env.dev ./config/.env
 	make db
-	./wait-for-healthy.sh 42world-backend-db-1
+	./wait-for-healthy.sh 42world-backend-db
 	yarn start:dev
 
 alpha:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   db:
     image: mysql:5.7
     platform: linux/x86_64
+    container_name: 42world-backend-db
     ports:
       - '${DB_PORT:-2345}:3306'
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,16 +33,3 @@ services:
       - NODE_ENV=${NODE_ENV:-alpha}
     depends_on:
       - db
-      - redis
-
-  redis:
-    image: redis:6.2.5
-    command: redis-server --port 6379
-    container_name: redis6379
-    hostname: redis6379
-    labels:
-      - "name=redis"
-      - "mode=standalone"
-    ports:
-      - ${REDIS_PORT:-6379}:6379
-

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -54,9 +54,6 @@ import { UserModule } from './user/user.module';
     }),
     DatabaseModule.register(),
     CacheModule.register({
-      store: redisStore,
-      host: process.env.REDIS_HOST ?? 'localhost',
-      port: process.env.REDIS_PORT ?? 6379,
       isGlobal: true,
     }),
     AwsSdkModule.forRootAsync({

--- a/src/ft-checkin/ft-checkin.module.ts
+++ b/src/ft-checkin/ft-checkin.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { FtCheckinService } from './ft-checkin.service';
 import { FtCheckinController } from './ft-checkin.controller';
+import { CacheModule } from '@cache/cache.module';
 
 @Module({
+  imports: [CacheModule],
   controllers: [FtCheckinController],
   providers: [FtCheckinService],
 })

--- a/src/ft-checkin/ft-checkin.service.ts
+++ b/src/ft-checkin/ft-checkin.service.ts
@@ -1,12 +1,7 @@
-import {
-  CACHE_MANAGER,
-  Injectable,
-  Inject,
-  NotFoundException,
-} from '@nestjs/common';
-import { Cache } from 'cache-manager';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import axios from 'axios';
 import { ApiProperty } from '@nestjs/swagger';
+import { CacheService } from '@cache/cache.service';
 
 const GAEPO = 'gaepo';
 const SEOCHO = 'seocho';
@@ -21,14 +16,14 @@ export class GetFtCheckinDto {
 
 @Injectable()
 export class FtCheckinService {
-  constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
+  constructor(private readonly cacheService: CacheService) {}
 
   async fetchData(
     cacheKey: string,
     cacheTTL: number,
     endpoint: string,
   ): Promise<GetFtCheckinDto> {
-    const ftCheckinData = await this.cacheManager.get<GetFtCheckinDto>(
+    const ftCheckinData = await this.cacheService.get<GetFtCheckinDto>(
       cacheKey,
     );
 
@@ -40,7 +35,7 @@ export class FtCheckinService {
           gaepo: data[GAEPO] || 0,
         };
 
-        await this.cacheManager.set(cacheKey, realData, {
+        await this.cacheService.set(cacheKey, realData, {
           ttl: cacheTTL,
         });
         return realData;


### PR DESCRIPTION
## 바뀐점
- ft-checkin에서 cache_manager 대신에 cache module을 사용하도록 수정
- redis 제거

## 바꾼이유
- 레디스 인스턴스 서비스 운영비용상의 문제로 redis를 사용하지 않고 메모리에 캐싱하는 방식으로 수정
- ft-checkin의 테스트를 편하게 하기 위해 cache module 적용
   - 직접 만든 module을 사용하면 mocking하기 쉬움