### PR TITLE
Feature: 댓글/리액션 쓰기/읽기 할때 카테고리 권한에 따라 작동하도록 변경

### DIFF
--- a/apps/api/src/article/article.controller.ts
+++ b/apps/api/src/article/article.controller.ts
@@ -124,6 +124,7 @@ export class ArticleController {
   }
 
   @Get(':id/comments')
+  @AlsoNovice()
   @ApiOperation({ summary: '게시글 댓글 가져오기' })
   @ApiPaginatedResponse(CommentResponseDto)
   async getComments(
@@ -148,6 +149,7 @@ export class ArticleController {
   }
 
   @Put(':id')
+  @AlsoNovice()
   @ApiOperation({ summary: '게시글 수정하기' })
   @ApiOkResponse({ description: '게시글 수정 완료' })
   @ApiNotFoundResponse({ description: '존재하지 않는 게시글' })
@@ -160,6 +162,7 @@ export class ArticleController {
   }
 
   @Delete(':id')
+  @AlsoNovice()
   @ApiOperation({ summary: '게시글 삭제하기' })
   @ApiOkResponse({ description: '게시글 삭제 완료' })
   @ApiNotFoundResponse({ description: '존재하지 않는 게시글' })

--- a/apps/api/src/article/article.controller.ts
+++ b/apps/api/src/article/article.controller.ts
@@ -127,20 +127,20 @@ export class ArticleController {
   @ApiOperation({ summary: '게시글 댓글 가져오기' })
   @ApiPaginatedResponse(CommentResponseDto)
   async getComments(
-    @GetUser('id') userId: number,
+    @GetUser() user: User,
     @Param('id', ParseIntPipe) articleId: number,
     @Query() options: PaginationRequestDto,
   ): Promise<PaginationResponseDto<CommentResponseDto> | never> {
     const { comments, totalCount } =
-      await this.commentService.findAllByArticleId(articleId, options);
+      await this.commentService.findAllByArticleId(user, articleId, options);
     const reactionComments =
-      await this.reactionService.findAllMyReactionComment(userId, articleId);
+      await this.reactionService.findAllMyReactionComment(user.id, articleId);
 
     return PaginationResponseDto.of({
       data: CommentResponseDto.ofArray({
         comments,
         reactionComments,
-        userId,
+        userId: user.id,
       }),
       options,
       totalCount,

--- a/apps/api/src/article/article.service.ts
+++ b/apps/api/src/article/article.service.ts
@@ -99,7 +99,6 @@ export class ArticleService {
         article: Article;
         category: Category;
         writer: User;
-        isLike: boolean;
       }
     | never
   > {
@@ -111,16 +110,11 @@ export class ArticleService {
       article.category,
       user,
     );
-    const isLike = await this.reactionService.isMyReactionArticle(
-      user.id,
-      article.id,
-    );
 
     return {
       article,
       category: article.category,
       writer: article.writer,
-      isLike,
     };
   }
 

--- a/apps/api/src/comment/comment.controller.ts
+++ b/apps/api/src/comment/comment.controller.ts
@@ -1,4 +1,4 @@
-import { GetUser } from '@api/auth/auth.decorator';
+import { AlsoNovice, GetUser } from '@api/auth/auth.decorator';
 import { User } from '@app/entity/user/user.entity';
 import {
   Body,
@@ -32,6 +32,7 @@ export class CommentController {
   constructor(private readonly commentService: CommentService) {}
 
   @Post()
+  @AlsoNovice()
   @ApiOperation({ summary: '댓글 생성' })
   @ApiCreatedResponse({
     description: '생성된 댓글',
@@ -54,6 +55,7 @@ export class CommentController {
   }
 
   @Put(':id')
+  @AlsoNovice()
   @ApiOperation({ summary: '댓글 수정' })
   @ApiOkResponse({ description: '댓글 수정 완료' })
   @ApiNotFoundResponse({ description: '존재하지 않거나, 내가 쓴게 아님' })
@@ -66,6 +68,7 @@ export class CommentController {
   }
 
   @Delete(':id')
+  @AlsoNovice()
   @ApiOperation({ summary: '댓글 삭제' })
   @ApiOkResponse({ description: '댓글 삭제 완료' })
   @ApiNotFoundResponse({ description: '존재하지 않거나, 내가 쓴게 아님' })

--- a/apps/api/src/comment/comment.controller.ts
+++ b/apps/api/src/comment/comment.controller.ts
@@ -12,6 +12,7 @@ import {
 import {
   ApiCookieAuth,
   ApiCreatedResponse,
+  ApiNotAcceptableResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -37,14 +38,12 @@ export class CommentController {
     type: CreateCommentRequestDto,
   })
   @ApiNotFoundResponse({ description: '존재하지 않는 게시글' })
+  @ApiNotAcceptableResponse({ description: '댓글을 쓸수없는 게시글' })
   async create(
     @GetUser() writer: User,
     @Body() createCommentDto: CreateCommentRequestDto,
   ): Promise<CommentResponseDto | never> {
-    const comment = await this.commentService.create(
-      writer.id,
-      createCommentDto,
-    );
+    const comment = await this.commentService.create(writer, createCommentDto);
 
     return CommentResponseDto.of({
       comment,

--- a/apps/api/src/comment/comment.module.ts
+++ b/apps/api/src/comment/comment.module.ts
@@ -1,4 +1,5 @@
 import { ArticleModule } from '@api/article/article.module';
+import { CategoryModule } from '@api/category/category.module';
 import { CommentRepository } from '@api/comment/repositories/comment.repository';
 import { NotificationModule } from '@api/notification/notification.module';
 import { forwardRef, Module } from '@nestjs/common';
@@ -8,6 +9,7 @@ import { CommentService } from './comment.service';
 
 @Module({
   imports: [
+    CategoryModule,
     NotificationModule,
     forwardRef(() => ArticleModule),
     TypeOrmModule.forFeature([CommentRepository]),

--- a/apps/api/src/comment/comment.service.ts
+++ b/apps/api/src/comment/comment.service.ts
@@ -1,8 +1,10 @@
 import { ArticleService } from '@api/article/article.service';
+import { CategoryService } from '@api/category/category.service';
 import { CommentRepository } from '@api/comment/repositories/comment.repository';
 import { NotificationService } from '@api/notification/notification.service';
 import { PaginationRequestDto } from '@api/pagination/dto/pagination-request.dto';
 import { Comment } from '@app/entity/comment/comment.entity';
+import { User } from '@app/entity/user/user.entity';
 import {
   forwardRef,
   Inject,
@@ -13,8 +15,6 @@ import {
 import { FindOneOptions } from 'typeorm';
 import { CreateCommentRequestDto } from './dto/request/create-comment-request.dto';
 import { UpdateCommentRequestDto } from './dto/request/update-comment-request.dto';
-import { User } from '@root/user/entities/user.entity';
-import { CategoryService } from '@root/category/category.service';
 
 @Injectable()
 export class CommentService {

--- a/apps/api/src/comment/comment.service.ts
+++ b/apps/api/src/comment/comment.service.ts
@@ -3,6 +3,7 @@ import { CategoryService } from '@api/category/category.service';
 import { CommentRepository } from '@api/comment/repositories/comment.repository';
 import { NotificationService } from '@api/notification/notification.service';
 import { PaginationRequestDto } from '@api/pagination/dto/pagination-request.dto';
+import { Category } from '@app/entity/category/category.entity';
 import { Comment } from '@app/entity/comment/comment.entity';
 import { User } from '@app/entity/user/user.entity';
 import {
@@ -53,6 +54,7 @@ export class CommentService {
   ): Promise<
     | {
         comments: Comment[];
+        category: Category;
         totalCount: number;
       }
     | never
@@ -62,7 +64,9 @@ export class CommentService {
       article.categoryId,
     );
     this.categoryService.checkAvailable('readableComment', category, user);
-    return this.commentRepository.findAllByArticleId(articleId, options);
+    const { comments, totalCount } =
+      await this.commentRepository.findAllByArticleId(articleId, options);
+    return { comments, category, totalCount };
   }
 
   findOneByIdOrFail(id: number, options?: FindOneOptions): Promise<Comment> {

--- a/apps/api/src/reaction/reaction.controller.ts
+++ b/apps/api/src/reaction/reaction.controller.ts
@@ -1,4 +1,4 @@
-import { GetUser } from '@api/auth/auth.decorator';
+import { AlsoNovice, GetUser } from '@api/auth/auth.decorator';
 import { Article } from '@app/entity/article/article.entity';
 import { Comment } from '@app/entity/comment/comment.entity';
 import { User } from '@app/entity/user/user.entity';
@@ -28,6 +28,7 @@ export class ReactionController {
   constructor(private readonly reactionService: ReactionService) {}
 
   @Post('articles/:id')
+  @AlsoNovice()
   @HttpCode(200)
   @ApiOperation({ summary: '게시글 좋아요 버튼' })
   @ApiCreatedResponse({
@@ -46,6 +47,7 @@ export class ReactionController {
   }
 
   @Post('articles/:articleId/comments/:commentId')
+  @AlsoNovice()
   @HttpCode(200)
   @ApiOperation({ summary: '댓글 좋아요 버튼' })
   @ApiCreatedResponse({

--- a/apps/api/src/reaction/reaction.controller.ts
+++ b/apps/api/src/reaction/reaction.controller.ts
@@ -1,6 +1,7 @@
 import { GetUser } from '@api/auth/auth.decorator';
 import { Article } from '@app/entity/article/article.entity';
 import { Comment } from '@app/entity/comment/comment.entity';
+import { User } from '@app/entity/user/user.entity';
 import {
   Controller,
   HttpCode,
@@ -35,11 +36,11 @@ export class ReactionController {
   })
   @ApiNotFoundResponse({ description: '존재하지 않는 게시글' })
   async reactionArticleCreateOrDelete(
-    @GetUser('id') userId: number,
+    @GetUser() user: User,
     @Param('id', ParseIntPipe) articleId: number,
   ): Promise<ReactionResponseDto | never> {
     const { article, isLike } =
-      await this.reactionService.articleCreateOrDelete(userId, articleId);
+      await this.reactionService.articleCreateOrDelete(user, articleId);
 
     return ReactionResponseDto.of<Article>({ entity: article, isLike });
   }
@@ -53,13 +54,13 @@ export class ReactionController {
   })
   @ApiNotFoundResponse({ description: '존재하지 않는 댓글' })
   async reactionCommentCreateOrDelete(
-    @GetUser('id') userId: number,
+    @GetUser() user: User,
     @Param('articleId', ParseIntPipe) articleId: number,
     @Param('commentId', ParseIntPipe) commentId: number,
   ): Promise<ReactionResponseDto | never> {
     const { comment, isLike } =
       await this.reactionService.commentCreateOrDelete(
-        userId,
+        user,
         articleId,
         commentId,
       );

--- a/apps/api/src/reaction/reaction.module.ts
+++ b/apps/api/src/reaction/reaction.module.ts
@@ -1,4 +1,5 @@
 import { ArticleModule } from '@api/article/article.module';
+import { CategoryModule } from '@api/category/category.module';
 import { CommentModule } from '@api/comment/comment.module';
 import { ReactionComment } from '@app/entity/reaction/reaction-comment.entity';
 import { forwardRef, Module } from '@nestjs/common';
@@ -9,6 +10,7 @@ import { ReactionArticleRepository } from './repositories/reaction-article.repos
 
 @Module({
   imports: [
+    CategoryModule,
     TypeOrmModule.forFeature([ReactionArticleRepository, ReactionComment]),
     forwardRef(() => ArticleModule),
     forwardRef(() => CommentModule),

--- a/apps/api/test/e2e/article.e2e-spec.ts
+++ b/apps/api/test/e2e/article.e2e-spec.ts
@@ -322,6 +322,26 @@ describe('Article', () => {
       expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
 
+    test('[성공] GET - 게시글 댓글 목록 조회 권한 높은사람', async () => {
+      const articleId = articles[0].id;
+
+      JWT = dummy.jwt2(users.admin[0], authService);
+      const response = await request(httpServer)
+        .get(`/articles/${articleId}/comments`)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
+      expect(response.status).toBe(HttpStatus.OK);
+    });
+
+    test('[실패] GET - 게시글 댓글 목록 조회 권한 낮은사람', async () => {
+      const articleId = articles[0].id;
+
+      JWT = dummy.jwt2(users.novice[0], authService);
+      const response = await request(httpServer)
+        .get(`/articles/${articleId}/comments`)
+        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
+      expect(response.status).toBe(HttpStatus.NOT_ACCEPTABLE);
+    });
+
     test('[실패] GET - 게시글 댓글 목록 존재하지 않는 게시글', async () => {
       const articleId = 99;
 

--- a/apps/api/test/e2e/comment.e2e-spec.ts
+++ b/apps/api/test/e2e/comment.e2e-spec.ts
@@ -193,14 +193,6 @@ describe('Comments', () => {
       expect(response.status).toEqual(HttpStatus.NOT_FOUND);
     });
 
-    test('[실패] PUT - 권한 없는 유저가 댓글 수정', async () => {
-      const response = await request(httpServer)
-        .delete(`/comments/${comment.id}`)
-        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${noviceJWT}`);
-
-      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
-    });
-
     test('[성공] DELETE - 댓글 삭제', async () => {
       const response = await request(httpServer)
         .delete(`/comments/${comment.id}`)
@@ -215,14 +207,6 @@ describe('Comments', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${anotherJWT}`);
 
       expect(response.status).toEqual(HttpStatus.NOT_FOUND);
-    });
-
-    test('[성공] DELETE - 권한 없는 유저가 댓글 삭제', async () => {
-      const response = await request(httpServer)
-        .delete(`/comments/${comment.id}`)
-        .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${noviceJWT}`);
-
-      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
     });
 
     test('[실패] DELETE & PUT - 삭제된 댓글 수정', async () => {

--- a/apps/api/test/e2e/reaction.e2e-spec.ts
+++ b/apps/api/test/e2e/reaction.e2e-spec.ts
@@ -108,6 +108,14 @@ describe('Reaction', () => {
       expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
 
+    test.skip('[성공] POST - 권한 높은 유저가 좋아요 하는 경우', async () => {
+      expect(1).toEqual(1);
+    });
+
+    test.skip('[실패] POST - 권한 낮은 유저가 좋아요 하는 경우', async () => {
+      expect(1).toEqual(1);
+    });
+
     test('[실패] POST - 없는 id를 보내는 경우', async () => {
       const notExistId = 0;
 
@@ -167,6 +175,14 @@ describe('Reaction', () => {
       );
 
       expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
+    });
+
+    test.skip('[성공] POST - 권한 높은 유저가 좋아요 하는 경우', async () => {
+      expect(1).toEqual(1);
+    });
+
+    test.skip('[실패] POST - 권한 낮은 유저가 좋아요 하는 경우', async () => {
+      expect(1).toEqual(1);
     });
 
     test('[실패] POST - 없는 articleId를 보내는 경우', async () => {

--- a/apps/api/test/e2e/reaction.e2e-spec.ts
+++ b/apps/api/test/e2e/reaction.e2e-spec.ts
@@ -176,7 +176,7 @@ describe('Reaction', () => {
         .post('/reactions/articles/' + notExistId + '/comments/1')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
 
-      expect(response.status).toEqual(HttpStatus.OK); // TODO - 코드가 이상하다 HttpStatus.OK을 돌려준다
+      expect(response.status).toEqual(HttpStatus.NOT_FOUND);
     });
 
     test('[실패] POST - 없는 commentId를 보내는 경우', async () => {

--- a/apps/api/test/e2e/reaction.e2e-spec.ts
+++ b/apps/api/test/e2e/reaction.e2e-spec.ts
@@ -108,10 +108,12 @@ describe('Reaction', () => {
       expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
 
+    // TODO: 여기 테스트 기능 구현할것
     test.skip('[성공] POST - 권한 높은 유저가 좋아요 하는 경우', async () => {
       expect(1).toEqual(1);
     });
 
+    // TODO: 여기 테스트 기능 구현할것
     test.skip('[실패] POST - 권한 낮은 유저가 좋아요 하는 경우', async () => {
       expect(1).toEqual(1);
     });
@@ -177,10 +179,12 @@ describe('Reaction', () => {
       expect(response.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
 
+    // TODO: 여기 테스트 기능 구현할것
     test.skip('[성공] POST - 권한 높은 유저가 좋아요 하는 경우', async () => {
       expect(1).toEqual(1);
     });
 
+    // TODO: 여기 테스트 기능 구현할것
     test.skip('[실패] POST - 권한 낮은 유저가 좋아요 하는 경우', async () => {
       expect(1).toEqual(1);
     });


### PR DESCRIPTION
## 바뀐점
댓글 쓸 때 카테고리 권한을 확인합니다.
댓글들을 가져올때 카테고리 권한을 확인합니다.
게시글 좋아요를 누를때 카테고리 권한을 확인합니다.
댓글 좋아요 누를때 카테고리 권한을 확인합니다.

## 설명
[comment.service.ts](https://github.com/42-world/42world-Backend/pull/182/files#diff-775b284d92b6ec217c18dbf2f06546b85a1bfc58254e6cf84669a0c256483933)
[reaction.service.ts](https://github.com/42-world/42world-Backend/pull/182/files#diff-6ef50315b22d42807724915b034fa002bf9f6551e57bb317ecad437c7b9ad9ce)
이 두 파일이 핵심적으로 변경되었습니다. 이 파일을 중점으로 리뷰 부탁드립니다.

* 아직 리액션 테스트는 구현하지 않았습니다.
* 카테고리에 너무 자주 접근하고있는데, 쿼리 최적화를 하거나, 캐싱을 써야할거같습니다..