### PR TITLE
Refactor: category test duplicate declaration

### DIFF
--- a/apps/api/test/e2e/category.e2e-spec.ts
+++ b/apps/api/test/e2e/category.e2e-spec.ts
@@ -37,7 +37,7 @@ describe('Category', () => {
       imports: [TestBaseModule, UserModule, AuthModule, CategoryModule],
     }).compile();
 
-    const app = createTestApp(moduleFixture);
+    app = createTestApp(moduleFixture);
     await app.init();
 
     userRepository = moduleFixture.get(UserRepository);

--- a/apps/api/test/e2e/category.e2e-spec.ts
+++ b/apps/api/test/e2e/category.e2e-spec.ts
@@ -18,7 +18,6 @@ import { getConnection } from 'typeorm';
 import * as dummy from './utils/dummy';
 
 describe('Category', () => {
-  let app: INestApplication;
   let userRepository: UserRepository;
   let categoryRepository: CategoryRepository;
   let authService: AuthService;
@@ -37,7 +36,7 @@ describe('Category', () => {
       imports: [TestBaseModule, UserModule, AuthModule, CategoryModule],
     }).compile();
 
-    app = createTestApp(moduleFixture);
+    const app = createTestApp(moduleFixture);
     await app.init();
 
     userRepository = moduleFixture.get(UserRepository);

--- a/apps/api/test/e2e/notification.e2e-spec.ts
+++ b/apps/api/test/e2e/notification.e2e-spec.ts
@@ -16,7 +16,6 @@ import { User } from '@app/entity/user/user.entity';
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import * as cookieParser from 'cookie-parser';
 import * as request from 'supertest';
 import { getConnection, Repository } from 'typeorm';
 import { TestBaseModule } from './test.base.module';
@@ -24,7 +23,7 @@ import * as dummy from './utils/dummy';
 import { clearDB, createTestApp } from './utils/utils';
 
 describe('Notification', () => {
-  let app: INestApplication;
+  let httpServer: INestApplication;
   let userRepository: UserRepository;
   let categoryRepository: CategoryRepository;
   let articleRepository: ArticleRepository;
@@ -44,10 +43,7 @@ describe('Notification', () => {
       ],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
-    app.use(cookieParser());
-
-    app = createTestApp(moduleFixture);
+    const app = createTestApp(moduleFixture);
     await app.init();
 
     userRepository = moduleFixture.get<UserRepository>(UserRepository);
@@ -59,13 +55,13 @@ describe('Notification', () => {
     );
     authService = moduleFixture.get<AuthService>(AuthService);
 
-    app = app.getHttpServer();
+    httpServer = app.getHttpServer();
   });
 
   afterAll(async () => {
     await getConnection().dropDatabase();
     await getConnection().close();
-    await app.close();
+    await httpServer.close();
   });
 
   beforeEach(async () => {
@@ -106,7 +102,7 @@ describe('Notification', () => {
     });
 
     test('[성공] GET - 알람 가져오기', async () => {
-      const res = await request(app)
+      const res = await request(httpServer)
         .get('/notifications')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
       expect(res.status).toEqual(HttpStatus.OK);
@@ -116,7 +112,7 @@ describe('Notification', () => {
     });
 
     test('[실패] GET - 로그인하지 않고 호출', async () => {
-      const res = await request(app).get('/notifications');
+      const res = await request(httpServer).get('/notifications');
       expect(res.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
   });
@@ -163,7 +159,7 @@ describe('Notification', () => {
     });
 
     test('[성공] PATCH - 알림 다 읽기', async () => {
-      const res = await request(app)
+      const res = await request(httpServer)
         .patch('/notifications/readall')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
       expect(res.status).toEqual(HttpStatus.OK);
@@ -176,7 +172,7 @@ describe('Notification', () => {
     });
 
     test('[실패] PATCH - 로그인하지 않고 호출', async () => {
-      const res = await request(app).patch('/notifications/readall');
+      const res = await request(httpServer).patch('/notifications/readall');
       expect(res.status).toEqual(HttpStatus.UNAUTHORIZED);
     });
   });

--- a/apps/api/test/e2e/notification.e2e-spec.ts
+++ b/apps/api/test/e2e/notification.e2e-spec.ts
@@ -46,14 +46,13 @@ describe('Notification', () => {
     const app = createTestApp(moduleFixture);
     await app.init();
 
-    userRepository = moduleFixture.get<UserRepository>(UserRepository);
-    categoryRepository =
-      moduleFixture.get<CategoryRepository>(CategoryRepository);
-    articleRepository = moduleFixture.get<ArticleRepository>(ArticleRepository);
-    notificationRepository = moduleFixture.get<Repository<Notification>>(
+    userRepository = moduleFixture.get(UserRepository);
+    categoryRepository = moduleFixture.get(CategoryRepository);
+    articleRepository = moduleFixture.get(ArticleRepository);
+    notificationRepository = moduleFixture.get(
       getRepositoryToken(Notification),
     );
-    authService = moduleFixture.get<AuthService>(AuthService);
+    authService = moduleFixture.get(AuthService);
 
     httpServer = app.getHttpServer();
   });


### PR DESCRIPTION
## 바뀐점
const app을 위에서 선언된 app을 사용하도록 변경
타입추론 적용

## 바꾼이유
위에서 선언된 app이 아래에서 다시 한번 선언되어 위의 app변수가 사용되지 않고 있었습니다

## 설명
