### PR TITLE
Hofix: category 가져오기 api 권한을 novice 도 허용 했습니다.

### DIFF
--- a/apps/api/src/category/category.controller.ts
+++ b/apps/api/src/category/category.controller.ts
@@ -1,4 +1,4 @@
-import { Admin, GetUser } from '@api/auth/auth.decorator';
+import { Admin, AlsoNovice, GetUser } from '@api/auth/auth.decorator';
 import { User } from '@app/entity/user/user.entity';
 import {
   Body,
@@ -46,6 +46,7 @@ export class CategoryController {
   }
 
   @Get()
+  @AlsoNovice()
   @ApiOperation({ summary: '카테고리 종류 가져오기' })
   @ApiOkResponse({
     description: '카테고리 종류',

--- a/apps/api/test/e2e/category.e2e-spec.ts
+++ b/apps/api/test/e2e/category.e2e-spec.ts
@@ -161,11 +161,18 @@ describe('Category', () => {
       expect(categories[2].name).toBe('유머게시판');
     });
 
-    test('[실패] GET - NOVICE가 카테고리 종류 가져오기', async () => {
+    test('[성공] GET - NOVICE가 카테고리 종류 가져오기', async () => {
       const response = await request(server)
         .get('/categories')
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${jwt.novice}`);
-      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
+      expect(response.status).toEqual(HttpStatus.OK);
+
+      const categories = response.body as CategoryResponseDto[];
+
+      expect(categories).toBeInstanceOf(Array);
+      expect(categories[0].name).toBe('자유게시판');
+      expect(categories[1].name).toBe('익명게시판');
+      expect(categories[2].name).toBe('유머게시판');
     });
 
     test('[실패] GET - unauthorized', async () => {


### PR DESCRIPTION
## 바뀐점
category api 권한을 누구나 확인가능하도록 합니다.
테스트도 수정되었습니다.

## 바꾼이유
세부 게시글 권한이 생겼기 때문에 카테고리 종류는 권한에 따라서 나눌필요가 없다고 판단했습니다.
