### PR TITLE
Chore: ignore README.md in testCI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Test CI
 on:
   pull_request:
     branches: ['**']
+    paths-ignore:
+        - "README.md"
 
 jobs:
   test:


### PR DESCRIPTION
## 바뀐점
README를 업데이트 할 때는 테스트가 돌아가지 않도록 했습니다

## 바꾼이유
최근 README를 업데이트 할 때 테스트가 쓸데없이 돌아가는것 같아 수정했습니다

## 설명
pr이름이 Docs: 로시작하는 pr은 무시하도록 할 수 있다면 더욱 좋을것 같습니다
특정 tag, branch는 인식할 수 있는것으로 보임