### PR TITLE
Refactor: test base module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ COMPOSE_ENV = ${COMPOSE} --env-file config/.env
 
 .PHONY: test
 test:
+	cp ./config/.env.test ./config/.env
 	./run_test_db.sh
 	./wait-for-healthy.sh ft_world-mysql-test
 	yarn test:e2e ./apps/api/test/e2e/*.e2e-spec.ts

--- a/apps/api/test/e2e/article.e2e-spec.ts
+++ b/apps/api/test/e2e/article.e2e-spec.ts
@@ -24,7 +24,7 @@ import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { getConnection } from 'typeorm';
-import { TestBaseModule } from './test.base.module';
+import { E2eTestBaseModule } from './e2e-test.base.module';
 import * as dummy from './utils/dummy';
 import { clearDB, createTestApp } from './utils/utils';
 import { testDto } from './utils/validate-test';
@@ -47,7 +47,7 @@ describe('Article', () => {
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
-        TestBaseModule,
+        E2eTestBaseModule,
         UserModule,
         AuthModule,
         ArticleModule,

--- a/apps/api/test/e2e/category.e2e-spec.ts
+++ b/apps/api/test/e2e/category.e2e-spec.ts
@@ -11,7 +11,7 @@ import { UserRole } from '@app/entity/user/interfaces/userrole.interface';
 import { User } from '@app/entity/user/user.entity';
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { TestBaseModule } from '@test/e2e/test.base.module';
+import { E2eTestBaseModule } from '@test/e2e/e2e-test.base.module';
 import { clearDB, createTestApp } from '@test/e2e/utils/utils';
 import * as request from 'supertest';
 import { getConnection } from 'typeorm';
@@ -33,7 +33,7 @@ describe('Category', () => {
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [TestBaseModule, UserModule, AuthModule, CategoryModule],
+      imports: [E2eTestBaseModule, UserModule, AuthModule, CategoryModule],
     }).compile();
 
     const app = createTestApp(moduleFixture);

--- a/apps/api/test/e2e/comment.e2e-spec.ts
+++ b/apps/api/test/e2e/comment.e2e-spec.ts
@@ -13,7 +13,7 @@ import { UserRole } from '@app/entity/user/interfaces/userrole.interface';
 import { User } from '@app/entity/user/user.entity';
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { TestBaseModule } from '@test/e2e/test.base.module';
+import { E2eTestBaseModule } from '@test/e2e/e2e-test.base.module';
 import { clearDB, createTestApp } from '@test/e2e/utils/utils';
 import * as request from 'supertest';
 import { getConnection } from 'typeorm';
@@ -47,7 +47,7 @@ describe('Comments', () => {
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
-        TestBaseModule,
+        E2eTestBaseModule,
         UserModule,
         AuthModule,
         ArticleModule,

--- a/apps/api/test/e2e/e2e-test.base.module.ts
+++ b/apps/api/test/e2e/e2e-test.base.module.ts
@@ -15,23 +15,23 @@ import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
 @Module({
   imports: [
-    TypeOrmModule.forRoot({
-      type: 'mysql',
-      host: 'localhost',
-      port: 3308,
-      username: 'ft_world',
-      password: 'ft_world',
-      database: 'ft_world',
-      entities: [path.join(__dirname, '../../../../libs/**/*.entity{.ts,.js}')],
-      namingStrategy: new SnakeNamingStrategy(),
-      synchronize: true,
-      logging: false,
-    }),
     ConfigModule.forRoot({
       envFilePath: 'config/.env',
       isGlobal: true,
       cache: true,
       load: [configEmail],
+    }),
+    TypeOrmModule.forRoot({
+      type: 'mysql',
+      host: process.env.DB_HOST,
+      port: parseInt(process.env.DB_PORT, 10),
+      username: process.env.DB_USER_NAME,
+      password: process.env.DB_USER_PASSWORD,
+      database: process.env.DB_NAME,
+      entities: [path.join(__dirname, '../../../../libs/**/*.entity{.ts,.js}')],
+      namingStrategy: new SnakeNamingStrategy(),
+      synchronize: true,
+      logging: false,
     }),
     AwsSdkModule.forRootAsync({
       defaultServiceOptions: {
@@ -54,4 +54,4 @@ import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
     },
   ],
 })
-export class TestBaseModule {}
+export class E2eTestBaseModule {}

--- a/apps/api/test/e2e/image.e2e-spec.ts
+++ b/apps/api/test/e2e/image.e2e-spec.ts
@@ -7,7 +7,7 @@ import { UserModule } from '@api/user/user.module';
 import { UserRole } from '@app/entity/user/interfaces/userrole.interface';
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { TestBaseModule } from '@test/e2e/test.base.module';
+import { E2eTestBaseModule } from '@test/e2e/e2e-test.base.module';
 import { clearDB, createTestApp } from '@test/e2e/utils/utils';
 import * as request from 'supertest';
 import { getConnection } from 'typeorm';
@@ -21,7 +21,7 @@ describe('Image', () => {
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [TestBaseModule, UserModule, AuthModule, ImageModule],
+      imports: [E2eTestBaseModule, UserModule, AuthModule, ImageModule],
     }).compile();
 
     const app = createTestApp(moduleFixture);

--- a/apps/api/test/e2e/intra-auth.e2e-spec.ts
+++ b/apps/api/test/e2e/intra-auth.e2e-spec.ts
@@ -13,7 +13,7 @@ import { MailerService } from '@nestjs-modules/mailer';
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
-import { TestBaseModule } from '@test/e2e/test.base.module';
+import { E2eTestBaseModule } from '@test/e2e/e2e-test.base.module';
 import { clearDB, createTestApp } from '@test/e2e/utils/utils';
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -37,7 +37,7 @@ describe('IntraAuth', () => {
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
-        TestBaseModule,
+        E2eTestBaseModule,
         UserModule,
         AuthModule,
         TypeOrmModule.forFeature([IntraAuth]),

--- a/apps/api/test/e2e/notification.e2e-spec.ts
+++ b/apps/api/test/e2e/notification.e2e-spec.ts
@@ -18,7 +18,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import * as request from 'supertest';
 import { getConnection, Repository } from 'typeorm';
-import { TestBaseModule } from './test.base.module';
+import { E2eTestBaseModule } from './e2e-test.base.module';
 import * as dummy from './utils/dummy';
 import { clearDB, createTestApp } from './utils/utils';
 
@@ -34,7 +34,7 @@ describe('Notification', () => {
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
-        TestBaseModule,
+        E2eTestBaseModule,
         UserModule,
         CategoryModule,
         ArticleModule,

--- a/apps/api/test/e2e/reaction.e2e-spec.ts
+++ b/apps/api/test/e2e/reaction.e2e-spec.ts
@@ -14,7 +14,7 @@ import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { getConnection } from 'typeorm';
-import { TestBaseModule } from './test.base.module';
+import { E2eTestBaseModule } from './e2e-test.base.module';
 import * as dummy from './utils/dummy';
 import { clearDB, createTestApp } from './utils/utils';
 
@@ -30,7 +30,7 @@ describe('Reaction', () => {
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
-        TestBaseModule,
+        E2eTestBaseModule,
         UserModule,
         AuthModule,
         ArticleModule,

--- a/apps/api/test/e2e/user.e2e-spec.ts
+++ b/apps/api/test/e2e/user.e2e-spec.ts
@@ -23,7 +23,7 @@ import * as dummy from '@test/e2e/utils/dummy';
 import { clearDB, createTestApp } from '@test/e2e/utils/utils';
 import * as request from 'supertest';
 import { getConnection } from 'typeorm';
-import { TestBaseModule } from './test.base.module';
+import { E2eTestBaseModule } from './e2e-test.base.module';
 
 describe('User', () => {
   let userRepository: UserRepository;
@@ -38,7 +38,7 @@ describe('User', () => {
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
-        TestBaseModule,
+        E2eTestBaseModule,
         UserModule,
         AuthModule,
         ArticleModule,


### PR DESCRIPTION
## 바뀐점
- test base module 이름 변경
- base module에서 데이터베이스 부분 설정이 env 값을 사용하도록 수정

## 바꾼이유
- e2e 테스트에서만 사용할것이기 때문에 좀 더 확실한 이름으로 변경
- test db에 붙는 값이 고정값으로 되어 있어서 env에 맞게 실행되도록 수정