### PR TITLE
fix: 자기가 쓴 댓글 알람 방지

### DIFF
--- a/apps/api/src/comment/comment.service.ts
+++ b/apps/api/src/comment/comment.service.ts
@@ -42,7 +42,10 @@ export class CommentService {
       ...createCommentDto,
       writerId: writer.id,
     });
-    this.notificationService.createNewComment(article, comment);
+
+    if (writer.id !== article.writerId) {
+      this.notificationService.createNewComment(article, comment);
+    }
     this.articleService.increaseCommentCount(article.id);
     return comment;
   }


### PR DESCRIPTION
## 바뀐점
알람 설정을 바꿈
## 바꾼이유
본인이 쓴 글에 본인이 댓글을 달면 알람이 옴
## 설명
- 글쓴이와 댓글 단 사람이 같지 않을 경우에만 알람을 생성