### PR TITLE
Hotfix: ft-checkin.service 복구

### DIFF
--- a/apps/api/test/e2e/best.e2e-spec.ts
+++ b/apps/api/test/e2e/best.e2e-spec.ts
@@ -9,9 +9,9 @@ import { UserRepository } from '@api/user/repositories/user.repository';
 import { UserModule } from '@api/user/user.module';
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { E2eTestBaseModule } from '@test/e2e/e2e-test.base.module';
 import * as request from 'supertest';
 import { getConnection } from 'typeorm';
-import { TestBaseModule } from './test.base.module';
 import * as dummy from './utils/dummy';
 import { clearDB, createTestApp } from './utils/utils';
 
@@ -32,7 +32,7 @@ describe('Best', () => {
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
-        TestBaseModule,
+        E2eTestBaseModule,
         UserModule,
         AuthModule,
         ArticleModule,


### PR DESCRIPTION
## 바뀐점
fft-checkin을 batch에서 생성한 cache에 있는 값을 가져오도록 수정

## 바꾼이유
ft-checkin.service file의 변경점이 conflict 해결과정중 사라진 부분을 복구
