### PR TITLE
Feat: 도커 파일 변경

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ RUN mkdir /home/ft-world
 
 WORKDIR /home/ft-world
 
-COPY apps apps
-COPY libs libs
-
 COPY nest-cli.json .
 COPY tsconfig.build.json .
 COPY tsconfig.json .
@@ -15,6 +12,10 @@ COPY package.json .
 COPY yarn.lock .
 
 RUN yarn install
+
+COPY libs libs
+COPY apps apps
+
 RUN yarn build
 
 ENTRYPOINT ["node", "dist/apps/api/src/main.js"]


### PR DESCRIPTION
## 바뀐점

도커파일의 명령어를 수정했습니다

## 바꾼이유

도커 파일 명령어는 하나씩 캐싱이 됩니다. 
위에서 아래로 체크하며 변경사항이 있을 시 해당 지점부터 아래 명령어를 전부 다시 처리합니다. 

기존에는 코드를 복사한 후에 npm install을 받았는데 이렇게 할 시 코드가 변경 될 때마다 라이브러리를 다시 다운 받습니다.

그래서 순서를 변경해서 npm install 후에 코드를 복사하도록 변경했습니다.

## 설명

![Screen Shot 2022-05-01 at 6 34 28 PM](https://user-images.githubusercontent.com/50068946/166140776-173c9dce-861f-4539-8181-89f40064a2f7.png)

코드 변경시 코드 변경 지점부터 빌드를 하고 npm install도 다시 합니다.

![Screen Shot 2022-05-01 at 6 38 01 PM](https://user-images.githubusercontent.com/50068946/166140779-d27551e3-5e54-4c40-968c-607f10117ff9.png)

코드를 변경하더라도 이전 내역은 캐시가 되어 넘어갑니다.




