### PR TITLE
Chore: Windows end of line lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+	'prettier/prettier': ["error", { "endOfLine": "auto" }],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-	'prettier/prettier': ["error", { "endOfLine": "auto" }],
+    'prettier/prettier': ["error", { "endOfLine": "auto" }],
   },
 };


### PR DESCRIPTION
## 바뀐점
eslint prettier의 endofline 설정 auto로 변경

## 바꾼이유
Windows 에서는 줄바꿈으로 CRLF를 사용하여 오류가 발생해 Windows 개발환경에서도 개발 할 수 있도록 수정

## 설명
