### PR TITLE
Fix: TimeZone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - MYSQL_PASSWORD=${DB_USER_PASSWORD}
       - MYSQL_ALLOW_EMPTY_PASSWORD=true
       - MYSQL_INITDB_ARGS=--encoding=UTF-8
-      - TZ=Asia/Seoul
+      - TZ=UTC
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     healthcheck:
       test: 'mysqladmin ping -h localhost -u ${DB_USER_NAME} --password=${DB_USER_PASSWORD}'

--- a/docker-stack-alpha.yml
+++ b/docker-stack-alpha.yml
@@ -10,7 +10,7 @@ services:
       - MYSQL_PASSWORD=ft_world
       - MYSQL_ALLOW_EMPTY_PASSWORD=true
       - MYSQL_INITDB_ARGS=--encoding=UTF-8
-      - TZ=Asia/Seoul
+      - TZ=UTC
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     volumes:
       - ./db:/var/lib/mysql

--- a/libs/common/src/database/ormconfig.ts
+++ b/libs/common/src/database/ormconfig.ts
@@ -25,7 +25,7 @@ export const ormconfig = (): IOrmconfig => ({
     entities: [__dirname + '../../../../**/*.entity{.ts,.js}'],
     namingStrategy: new SnakeNamingStrategy(),
 
-    timezone: '+09:00', // KST
+    timezone: 'Z', // UTC
 
     synchronize: false,
     migrationsRun: true,


### PR DESCRIPTION
## 바뀐점
- typeorm의 타임존을 KST에서 UTC로 변경
- docker-compose로 생성되는 DB의 타임존을 UTC로 변경
- docker-stack로 생성되는 알파 DB의 타임존을 UTC로 변경

## 바꾼이유
- 현재 RDS의 타임존이 UTC로 잡혀있어서 이에 맞게 타임존을 변경
- 타임존을 제대로 테스트하기 위해 로컬 및 알파환경에서도 UTC로 만들어지도록 수정
