### PR TITLE
Fix: jwt 시크릿키 env 사용하지 않고 있던 문제 수정

### DIFF
--- a/apps/api/src/auth/auth.constant.ts
+++ b/apps/api/src/auth/auth.constant.ts
@@ -1,5 +1,5 @@
 export const jwtConstants = {
-  secret: 'secretKey',
+  secret: process.env.JWT_SECRET,
 };
 
 export const FORBIDDEN_USER_ROLE = '접근 권한 없음';


### PR DESCRIPTION
## 바뀐점
- jwt 암호화 및 복호화에 사용하는 secret key를 env로 관리하도록

## 바꾼이유
- 원래 env를 사용했어야했는데 누락되어 있었음
