### PR TITLE
Feat: seed 데이터 보강

### DIFF
--- a/libs/common/src/database/seeder/intra-auth/data.ts
+++ b/libs/common/src/database/seeder/intra-auth/data.ts
@@ -1,0 +1,21 @@
+import { IntraAuth } from '@app/entity/intra-auth/intra-auth.entity';
+import { PartialType } from '@nestjs/mapped-types';
+
+export class SeederDataIntraAuth extends PartialType(IntraAuth) {
+  id: number;
+  intraId: string;
+  userId: number;
+}
+
+export const intraAuthData: SeederDataIntraAuth[] = [
+  {
+    id: 1,
+    intraId: 'cadetUserIntraId',
+    userId: 2,
+  },
+  {
+    id: 2,
+    intraId: 'adminUserIntraId',
+    userId: 3,
+  },
+];

--- a/libs/common/src/database/seeder/intra-auth/intra-auth-seeder.module.ts
+++ b/libs/common/src/database/seeder/intra-auth/intra-auth-seeder.module.ts
@@ -1,0 +1,11 @@
+import { IntraAuthSeederService } from '@app/common/database/seeder/intra-auth/intra-auth-seeder.service';
+import { IntraAuth } from '@app/entity/intra-auth/intra-auth.entity';
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([IntraAuth])],
+  providers: [IntraAuthSeederService],
+  exports: [IntraAuthSeederService],
+})
+export class IntraAuthSeederModule {}

--- a/libs/common/src/database/seeder/intra-auth/intra-auth-seeder.service.ts
+++ b/libs/common/src/database/seeder/intra-auth/intra-auth-seeder.service.ts
@@ -1,0 +1,17 @@
+import { intraAuthData } from '@app/common/database/seeder/intra-auth/data';
+import { IntraAuth } from '@app/entity/intra-auth/intra-auth.entity';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class IntraAuthSeederService {
+  constructor(
+    @InjectRepository(IntraAuth)
+    private readonly intraRepository: Repository<IntraAuth>,
+  ) {}
+
+  create() {
+    return this.intraRepository.save(intraAuthData);
+  }
+}

--- a/libs/common/src/database/seeder/seeder.module.ts
+++ b/libs/common/src/database/seeder/seeder.module.ts
@@ -1,5 +1,6 @@
 import { DatabaseModule } from '@app/common/database/database.module';
 import { ormconfig } from '@app/common/database/ormconfig';
+import { IntraAuthSeederModule } from '@app/common/database/seeder/intra-auth/intra-auth-seeder.module';
 import { Logger, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ArticleSeederModule } from './article/article-seeder.module';
@@ -19,6 +20,7 @@ import { UserSeederModule } from './user/user-seeder.module';
     UserSeederModule,
     CategorySeederModule,
     ArticleSeederModule,
+    IntraAuthSeederModule,
   ],
   providers: [Logger, Seeder],
 })

--- a/libs/common/src/database/seeder/seeder.ts
+++ b/libs/common/src/database/seeder/seeder.ts
@@ -1,3 +1,4 @@
+import { IntraAuthSeederService } from '@app/common/database/seeder/intra-auth/intra-auth-seeder.service';
 import { Injectable } from '@nestjs/common';
 import { ArticleSeederService } from './article/article-seeder.service';
 import { CategorySeederService } from './category/category-seeder.service';
@@ -9,6 +10,7 @@ export class Seeder {
     private readonly userSeederService: UserSeederService,
     private readonly categorySeederService: CategorySeederService,
     private readonly articleSeederService: ArticleSeederService,
+    private readonly intraAuthSeederService: IntraAuthSeederService,
   ) {}
 
   async seed() {
@@ -16,6 +18,7 @@ export class Seeder {
       this.userSeederService.create(),
       this.categorySeederService.create(),
       this.articleSeederService.create(),
+      this.intraAuthSeederService.create(),
     ]);
   }
 }

--- a/libs/common/src/database/seeder/user/data.ts
+++ b/libs/common/src/database/seeder/user/data.ts
@@ -13,16 +13,23 @@ export class SeederDataUser extends PartialType(User) {
 export const users: SeederDataUser[] = [
   {
     id: 1,
-    githubUid: 'test1234',
-    nickname: 'first_user',
-    githubUsername: 'github_first_user',
-    role: UserRole.CADET,
+    githubUid: 'noviceUserGithubUid',
+    nickname: 'noviceUserNickName',
+    githubUsername: 'noviceGithubUserName',
+    role: UserRole.NOVICE,
   },
   {
     id: 2,
-    githubUid: 'test2345',
-    nickname: 'second_user',
-    githubUsername: 'github_second_user',
-    role: UserRole.NOVICE,
+    githubUid: 'cadetGithubUid',
+    nickname: 'cadetNickname',
+    githubUsername: 'cadetGithubUsername',
+    role: UserRole.CADET,
+  },
+  {
+    id: 3,
+    githubUid: 'adminGithubUid',
+    nickname: 'adminNickname',
+    githubUsername: 'adminGithubUsername',
+    role: UserRole.ADMIN,
   },
 ];


### PR DESCRIPTION
## 바뀐점
- user seed 데이터를 권한별로 만들도록 수정
   - novice, cadet, admin
- user 데이터에 맞게 intra-auth 데이터도 생성

## 바꾼이유
- 여러 권한을 가진 계정이 개발할때 필요해서 변경하였음

<img width="936" alt="스크린샷 2022-05-21 오전 1 33 56" src="https://user-images.githubusercontent.com/8137615/169572649-9e9f3149-3297-4d3b-a9c6-9a9f809efe94.png">

