### PR TITLE
Fix: jwt secret key, env를 제대로 안읽어와서 생긴 문제 수정, 유저 토큰 파싱이 안되던 문제

### DIFF
--- a/apps/api/src/auth/auth.constant.ts
+++ b/apps/api/src/auth/auth.constant.ts
@@ -1,7 +1,3 @@
-export const jwtConstants = {
-  secret: process.env.JWT_SECRET,
-};
-
 export const FORBIDDEN_USER_ROLE = '접근 권한 없음';
 
 // metadata keys

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,8 +1,8 @@
 import { UserModule } from '@api/user/user.module';
 import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
-import { jwtConstants } from './auth.constant';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { GithubStrategy } from './github.strategy';
@@ -12,9 +12,14 @@ import { JwtStrategy } from './jwt.strategy';
   imports: [
     UserModule,
     PassportModule,
-    JwtModule.register({
-      secret: jwtConstants.secret,
-      signOptions: { expiresIn: '7d' },
+    ConfigModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get('JWT_SECRET'),
+        signOptions: { expiresIn: '7d' },
+      }),
     }),
   ],
   providers: [AuthService, GithubStrategy, JwtStrategy],

--- a/apps/api/src/auth/jwt.strategy.ts
+++ b/apps/api/src/auth/jwt.strategy.ts
@@ -5,9 +5,9 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { jwtConstants } from './auth.constant';
 import { JWTPayload } from './interfaces/jwt-payload.interface';
 
 const getAccessToken = (request: any): string => {
@@ -20,11 +20,14 @@ const getAccessToken = (request: any): string => {
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(private userService: UserService) {
+  constructor(
+    private userService: UserService,
+    private configService: ConfigService,
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([getAccessToken]),
       ignoreExpiration: false,
-      secretOrKey: jwtConstants.secret,
+      secretOrKey: configService.get('JWT_SECRET'),
     });
   }
 


### PR DESCRIPTION
## 바뀐점
- auth.module과 jwt.strategy에서 env를 process.env로 가져오는 방식을 사용하고 있던 부분 변경
 
## 바꾼이유
- 서버 시작할때 jwt secret key가 비어있다고 서버가 안켜지는 문제 때문에 수정

## 설명
- auth module이 로드 되는 시점에서는 process.env가 비어있어서 제대로 안되는 문제가 있음
- registerAsync로 env가 로드 된 이후의 시점에 사용 할 수 있도록 처리하였음