### PR TITLE
Fix: sentry intercetopr에서 에러를 다시 전달 안해주는 문제 수정

### DIFF
--- a/apps/api/src/sentry.interceptor.ts
+++ b/apps/api/src/sentry.interceptor.ts
@@ -5,7 +5,7 @@ import {
   NestInterceptor,
 } from '@nestjs/common';
 import * as Sentry from '@sentry/minimal';
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -14,7 +14,7 @@ export class SentryInterceptor implements NestInterceptor {
     return next.handle().pipe(
       catchError((error) => {
         Sentry.captureException(error);
-        return null;
+        return throwError(() => error);
       }),
     );
   }


### PR DESCRIPTION
## 바뀐점
- sentry.interceptor에서 에러를 처리한 이후에 에러를 다시 전달하도록 수정하였음

## 바꾼이유
- Fix: sentry interceptor에서 에러를 다시 전달 안해주는 문제가 있어서 수정하였음

## 설명
- 참고자료: https://docs.nestjs.com/interceptors#exception-mapping