### PR TITLE
Fix: 42인증하지 않은 유저도 로그아웃 가능하도록 변경

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -62,6 +62,7 @@ export class AuthController {
   }
 
   @Delete('signout')
+  @Public()
   @ApiCookieAuth()
   @ApiOperation({ summary: '로그아웃' })
   @ApiOkResponse({ description: '로그아웃 성공' })


### PR DESCRIPTION
## 바뀐점
로그아웃 컨트롤러 권한을 Public으로 변경하였습니다.

## 바꾼이유
Public으로 되어있지 않아서 외부인은 사용하지 못하고 있었음

## 설명
