### PR TITLE
Feat: 내정보 가져오기 api, novice도 가능하도록 수정

### DIFF
--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -42,6 +42,7 @@ export class UserController {
   ) {}
 
   @Get('me')
+  @AlsoNovice()
   @ApiOperation({ summary: '내 정보 가져오기' })
   @ApiOkResponse({ description: '내 정보', type: UserResponseDto })
   findOne(@GetUser() user: User): UserResponseDto {


### PR DESCRIPTION
## 바뀐점
- user/me api를 novice도 사용 가능하도록 수정

## 바꾼이유
- 프론트 리팩토링을 진행하던중 내정보를 가져오는 api는 하나로만 사용하는게 구조적으로 좋을거 같아서 수정함
- 내정보를 가져오는 api인데 권한이 없는것도 이상하기도 함
- 이제 외부 인원도 사용 할 수 있게 되면 어차피 42인증 없이도 본인 정보 볼수 있어야하기 때문에 수정함

## 설명
