### PR TITLE
Fix: makefile, clean-all db 파일 삭제, 경로 수정

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ clean:
 	cd infra && ${COMPOSE} down
 
 clean-all: clean
-	rm -rf db dist
+	rm -rf infra/db dist
 
 swarm-clean:
 	docker service rm $(shell docker service ls -q)


### PR DESCRIPTION
## 바뀐점
- makefile에 clean-all의 삭제 경로 수정

## 바꾼이유
- intra 경로가 생기면서 db 경로도 바뀌었는데 반영이 안되어 있었음

## 설명
