### PR TITLE
Fix: prettier 설정이 적용이 안되던 문제 수정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,10 +6,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
   },
   plugins: ['@typescript-eslint/eslint-plugin'],
-  extends: [
-    'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
-  ],
+  extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'],
   root: true,
   env: {
     node: true,
@@ -21,6 +18,5 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-    'prettier/prettier': ["error", { "endOfLine": "auto" }],
   },
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
   "trailingComma": "all",
-  "printWidth": 80
+  "printWidth": 120,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
## 바뀐점
- eslint rules에 'prettier/prettier' 옵션 제거

## 바꾼이유
- 설정하면 prettierrc 파일을 읽지 않기 때문에 제거하였음

## 설명

https://github.com/prettier/eslint-plugin-prettier#options
<img width="871" alt="스크린샷 2022-06-05 오후 2 09 32" src="https://user-images.githubusercontent.com/8137615/172035967-07aa29e4-47cc-4e95-ac91-6e420eee2337.png">

