### PR TITLE
Fix: http error

### DIFF
--- a/apps/api/src/article/article.service.ts
+++ b/apps/api/src/article/article.service.ts
@@ -4,8 +4,8 @@ import { Article } from '@app/entity/article/article.entity';
 import { Category } from '@app/entity/category/category.entity';
 import { User } from '@app/entity/user/user.entity';
 import {
+  ForbiddenException,
   Injectable,
-  NotAcceptableException,
   NotFoundException,
 } from '@nestjs/common';
 import { CreateArticleRequestDto } from './dto/request/create-article-request.dto';
@@ -90,9 +90,7 @@ export class ArticleService {
   }> {
     const availableCategories = await this.categoryService.getAvailable(user);
     if (!availableCategories.some((category) => category.id === categoryId)) {
-      throw new NotAcceptableException(
-        `Category ${categoryId} is not available`,
-      );
+      throw new ForbiddenException(`Category ${categoryId} is not available`);
     }
     const { articles, totalCount } =
       await this.articleRepository.searchByCategory(categoryId, options);
@@ -210,7 +208,7 @@ export class ArticleService {
 
   async decreaseLikeCount(article: Article): Promise<Article | never> {
     if (article.likeCount <= 0) {
-      throw new NotAcceptableException('좋아요는 0이하가 될 수 없습니다.');
+      throw new ForbiddenException('좋아요는 0이하가 될 수 없습니다.');
     }
     await this.articleRepository.update(article.id, {
       likeCount: () => 'like_count - 1',

--- a/apps/api/src/article/article.service.ts
+++ b/apps/api/src/article/article.service.ts
@@ -4,6 +4,7 @@ import { Article } from '@app/entity/article/article.entity';
 import { Category } from '@app/entity/category/category.entity';
 import { User } from '@app/entity/user/user.entity';
 import {
+  BadRequestException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -208,7 +209,7 @@ export class ArticleService {
 
   async decreaseLikeCount(article: Article): Promise<Article | never> {
     if (article.likeCount <= 0) {
-      throw new ForbiddenException('좋아요는 0이하가 될 수 없습니다.');
+      throw new BadRequestException('좋아요는 0이하가 될 수 없습니다.');
     }
     await this.articleRepository.update(article.id, {
       likeCount: () => 'like_count - 1',

--- a/apps/api/src/category/category.service.ts
+++ b/apps/api/src/category/category.service.ts
@@ -3,8 +3,8 @@ import { UserRole } from '@app/entity/user/interfaces/userrole.interface';
 import { User } from '@app/entity/user/user.entity';
 import { compareRole, includeRole } from '@app/utils/utils';
 import {
+  ForbiddenException,
   Injectable,
-  NotAcceptableException,
   NotFoundException,
 } from '@nestjs/common';
 import { CreateCategoryRequestDto } from './dto/request/create-category-request.dto';
@@ -58,7 +58,7 @@ export class CategoryService {
     user: User,
   ): void | never {
     if (!compareRole(category[key] as UserRole, user.role as UserRole))
-      throw new NotAcceptableException(
+      throw new ForbiddenException(
         `당신은 ${category.name} 카테고리의 ${key} 하지 않습니다.`,
       );
   }

--- a/apps/api/src/comment/comment.controller.ts
+++ b/apps/api/src/comment/comment.controller.ts
@@ -12,7 +12,7 @@ import {
 import {
   ApiCookieAuth,
   ApiCreatedResponse,
-  ApiNotAcceptableResponse,
+  ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -39,7 +39,7 @@ export class CommentController {
     type: CreateCommentRequestDto,
   })
   @ApiNotFoundResponse({ description: '존재하지 않는 게시글' })
-  @ApiNotAcceptableResponse({ description: '댓글을 쓸수없는 게시글' })
+  @ApiForbiddenResponse({ description: '댓글을 쓸수없는 게시글' })
   async create(
     @GetUser() writer: User,
     @Body() createCommentDto: CreateCommentRequestDto,

--- a/apps/api/src/comment/comment.service.ts
+++ b/apps/api/src/comment/comment.service.ts
@@ -7,10 +7,10 @@ import { Category } from '@app/entity/category/category.entity';
 import { Comment } from '@app/entity/comment/comment.entity';
 import { User } from '@app/entity/user/user.entity';
 import {
+  BadRequestException,
   forwardRef,
   Inject,
   Injectable,
-  NotAcceptableException,
   NotFoundException,
 } from '@nestjs/common';
 import { FindOneOptions } from 'typeorm';
@@ -129,7 +129,7 @@ export class CommentService {
 
   async decreaseLikeCount(comment: Comment): Promise<Comment> {
     if (comment.likeCount <= 0) {
-      throw new NotAcceptableException('좋아요는 0이하가 될 수 없습니다.');
+      throw new BadRequestException('좋아요는 0이하가 될 수 없습니다.');
     }
     await this.commentRepository.update(comment.id, {
       likeCount: () => 'like_count - 1',

--- a/apps/api/test/e2e/article.e2e-spec.ts
+++ b/apps/api/test/e2e/article.e2e-spec.ts
@@ -146,7 +146,7 @@ describe('Article', () => {
         .post('/articles')
         .send(createArticlRequesteDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(HttpStatus.NOT_ACCEPTABLE);
+      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
     });
 
     test('[실패] POST - 글쓰기 존재하지 않는 카테고리', async () => {
@@ -275,7 +275,7 @@ describe('Article', () => {
         .get('/articles')
         .query(findArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(HttpStatus.NOT_ACCEPTABLE);
+      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
     });
 
     test('[실패] GET - 게시글 목록 조희 존재하지 않는 카테고리', async () => {
@@ -397,7 +397,7 @@ describe('Article', () => {
       const response = await request(httpServer)
         .get(`/articles/${articleId}/comments`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toBe(HttpStatus.NOT_ACCEPTABLE);
+      expect(response.status).toBe(HttpStatus.FORBIDDEN);
     });
 
     test('[실패] GET - 게시글 댓글 목록 존재하지 않는 게시글', async () => {
@@ -508,7 +508,7 @@ describe('Article', () => {
       const response = await request(httpServer)
         .get(`/articles/${articleId}`)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
-      expect(response.status).toEqual(HttpStatus.NOT_ACCEPTABLE);
+      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
     });
 
     test('[실패] GET - 게시글 상세 조회 존재하지 않는 게시글', async () => {
@@ -974,7 +974,7 @@ describe('Article', () => {
         .query(SearchArticleRequestDto)
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${noviceJWT}`);
 
-      expect(response.status).toEqual(HttpStatus.NOT_ACCEPTABLE);
+      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
     });
   });
 });

--- a/apps/api/test/e2e/comment.e2e-spec.ts
+++ b/apps/api/test/e2e/comment.e2e-spec.ts
@@ -158,7 +158,7 @@ describe('Comments', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${noviceJWT}`)
         .send({ content: commentContent, articleId: targetArticle.id });
 
-      expect(response.status).toEqual(HttpStatus.NOT_ACCEPTABLE);
+      expect(response.status).toEqual(HttpStatus.FORBIDDEN);
     });
   });
 


### PR DESCRIPTION
## 바뀐점
- 카테고리 관련 권한 에러 status를 406에서 403으로 변경
- 댓글 좋아요 0이하 관련 에러 status 406에서 400으로 변경
- 게시글 좋아요 0이하 관련 에러 status 403에서 400으로 변경

## 바꾼이유
- http 표준의 의미와 맞지 않기 때문

## 설명
아래의 자료를 참고

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406
https://www.whatap.io/ko/blog/40/
