### PR TITLE
Fix: actions-yarn 버전 3.0.0으로 변경

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - name: GitHub Action for Yarn
-        uses: Borales/actions-yarn@v2.3.0
+        uses: Borales/actions-yarn@v3.0.0
       - run: make test


### PR DESCRIPTION
## 바뀐점
actions-yarn 버전 3.0.0으로 변경

## 바꾼이유
기존 2.3.0 버전에서 python2 가 지원되지 않아
test 가 정상적으로 작동하지 않았음

## 설명
