### PR TITLE
Fix: on.push trigger 설정

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,11 +12,14 @@
 name: "CodeQL"
 
 on:
+  push:
+    branches: [ develop ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ develop ]
     paths-ignore:
-        - "README.md"
+        - '**/*.md'
+        - '**/*.txt'
   schedule:
     - cron: '17 16 * * 5'
 


### PR DESCRIPTION
## 바뀐점
on.push trigger를 설정하고
paths-ignore에 텍스트파일들 무시하도록 추가

## 바꾼이유
codeQL warning을 확인하려면 on.push를 trigger해야한다고 하더라구요

## 설명
