### PR TITLE
Fix: tsconfig outDir 수정

### DIFF
--- a/apps/admin/tsconfig.app.json
+++ b/apps/admin/tsconfig.app.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": false,
-    "outDir": "../../dist/apps/admin"
+    "declaration": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]

--- a/apps/batch/tsconfig.app.json
+++ b/apps/batch/tsconfig.app.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": false,
-    "outDir": "../../dist/apps/batch"
+    "declaration": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]


### PR DESCRIPTION
## 바뀐점
outDIr 속성 삭제함

## 바꾼이유
build시 outDir 때문에 nest-cli 값과 충돌해서 제대로 빌드가 안되고있었음

## 설명
