### PR TITLE
Feat: user profile api에 intraId 추가

### DIFF
--- a/apps/api/src/user/dto/response/base-user-response.dto.ts
+++ b/apps/api/src/user/dto/response/base-user-response.dto.ts
@@ -1,0 +1,32 @@
+import { UserRole } from '@app/entity/user/interfaces/userrole.interface';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsString, Max, Min } from 'class-validator';
+
+export class BaseUserResponseDto {
+  @ApiProperty()
+  id!: number;
+
+  @IsString()
+  @ApiProperty()
+  nickname!: string;
+
+  @IsString()
+  @ApiProperty({ example: UserRole.NOVICE })
+  role!: UserRole;
+
+  @IsInt()
+  @Min(0)
+  @Max(10)
+  @ApiProperty({
+    minimum: 0,
+    maximum: 10,
+  })
+  character!: number;
+
+  constructor(id: number, nickname: string, role: UserRole, character: number) {
+    this.id = id;
+    this.nickname = nickname;
+    this.role = role;
+    this.character = character;
+  }
+}

--- a/apps/api/src/user/dto/response/user-profile-response.dto.ts
+++ b/apps/api/src/user/dto/response/user-profile-response.dto.ts
@@ -1,0 +1,15 @@
+import { BaseUserResponseDto } from '@api/user/dto/response/base-user-response.dto';
+import { UserRole } from '@app/entity/user/interfaces/userrole.interface';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class UserProfileResponseDto extends BaseUserResponseDto {
+  @IsString()
+  @ApiProperty({ required: false, example: 'chlim' })
+  intraId: string | null;
+
+  constructor(id: number, nickname: string, role: UserRole, character: number, intraId: string | null) {
+    super(id, nickname, role, character);
+    this.intraId = intraId;
+  }
+}

--- a/apps/api/src/user/dto/response/user-profile-response.dto.ts
+++ b/apps/api/src/user/dto/response/user-profile-response.dto.ts
@@ -5,7 +5,7 @@ import { IsString } from 'class-validator';
 
 export class UserProfileResponseDto extends BaseUserResponseDto {
   @IsString()
-  @ApiProperty({ required: false, example: 'chlim' })
+  @ApiProperty({ required: false, example: 'chlim', nullable: true })
   intraId: string | null;
 
   constructor(id: number, nickname: string, role: UserRole, character: number, intraId: string | null) {

--- a/apps/api/src/user/dto/user-profile.mapper.ts
+++ b/apps/api/src/user/dto/user-profile.mapper.ts
@@ -1,0 +1,9 @@
+import { UserProfileResponseDto } from '@api/user/dto/response/user-profile-response.dto';
+import { IntraAuth } from '@app/entity/intra-auth/intra-auth.entity';
+import { User } from '@app/entity/user/user.entity';
+
+export class UserProfileMapper {
+  static async toMapResponse(user: User, intraAuth?: IntraAuth): Promise<UserProfileResponseDto> {
+    return new UserProfileResponseDto(user.id, user.nickname, user.role, user.character, intraAuth.intraId);
+  }
+}

--- a/apps/api/src/user/dto/user-profile.mapper.ts
+++ b/apps/api/src/user/dto/user-profile.mapper.ts
@@ -3,7 +3,7 @@ import { IntraAuth } from '@app/entity/intra-auth/intra-auth.entity';
 import { User } from '@app/entity/user/user.entity';
 
 export class UserProfileMapper {
-  static async toMapResponse(user: User, intraAuth?: IntraAuth): Promise<UserProfileResponseDto> {
-    return new UserProfileResponseDto(user.id, user.nickname, user.role, user.character, intraAuth.intraId);
+  static async toMapResponse(user: User, intraAuth?: IntraAuth | null): Promise<UserProfileResponseDto> {
+    return new UserProfileResponseDto(user.id, user.nickname, user.role, user.character, intraAuth?.intraId);
   }
 }

--- a/apps/api/src/user/dto/user-profile.mapper.ts
+++ b/apps/api/src/user/dto/user-profile.mapper.ts
@@ -3,7 +3,7 @@ import { IntraAuth } from '@app/entity/intra-auth/intra-auth.entity';
 import { User } from '@app/entity/user/user.entity';
 
 export class UserProfileMapper {
-  static async toMapResponse(user: User, intraAuth?: IntraAuth | null): Promise<UserProfileResponseDto> {
+  static toMapResponse(user: User, intraAuth?: IntraAuth | null): UserProfileResponseDto {
     return new UserProfileResponseDto(user.id, user.nickname, user.role, user.character, intraAuth?.intraId);
   }
 }

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -32,7 +32,7 @@ export class UserController {
   @AlsoNovice()
   @ApiOperation({ summary: '내 정보 가져오기' })
   @ApiOkResponse({ description: '내 정보', type: UserProfileResponseDto })
-  async me(@GetUser() user: User) {
+  async me(@GetUser() user: User): Promise<UserProfileResponseDto> {
     const intraAuth = await user.intraAuth;
     return UserProfileMapper.toMapResponse(user, intraAuth);
   }

--- a/libs/entity/src/user/user.entity.ts
+++ b/libs/entity/src/user/user.entity.ts
@@ -85,5 +85,5 @@ export class User extends BaseEntity {
     createForeignKeyConstraints: false,
     nullable: false,
   })
-  intraAuth?: Promise<IntraAuth>;
+  intraAuth?: Promise<IntraAuth | null>;
 }

--- a/libs/entity/src/user/user.entity.ts
+++ b/libs/entity/src/user/user.entity.ts
@@ -36,7 +36,7 @@ export class User extends BaseEntity {
   lastLogin?: Date;
 
   @Column({ type: 'enum', enum: UserRole, default: UserRole.NOVICE })
-  role!: string;
+  role!: UserRole;
 
   @Column({ nullable: false, default: 0 })
   character!: number;

--- a/libs/entity/src/user/user.entity.ts
+++ b/libs/entity/src/user/user.entity.ts
@@ -85,5 +85,5 @@ export class User extends BaseEntity {
     createForeignKeyConstraints: false,
     nullable: false,
   })
-  intraAuth?: IntraAuth;
+  intraAuth?: Promise<IntraAuth>;
 }


### PR DESCRIPTION
## 바뀐점
- user profile api에 intraId 추가
- user role 타입이 string으로 되어 있어서 enum으로 변경
- user.entity의 intraAuth를 LazyLoad 할 수 있도록 Promise 처리
- java spring 스타일로 dto 작성

## 바꾼이유
- 마이페이지에서 intraId도 같이 보여줘야해서 추가하였음
- LazyLoad를 사용해보고 싶어서 적용해보았음
- dto가 api의 결과를 나타내는 역할을 할 수 있기 때문에 명시적으로 전부 작성하는 방법을 선택하였음
   - 전부 명시적으로 작성하다보니 java spring 스타일처럼 dto가 작성되었음(getter, setter는 없지만)

## 설명
