### PR TITLE
Chore: test build 추가

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,6 @@ jobs:
           cache: 'yarn'
       - run: yarn
       - run: make test
+      - run: yarn build api
+      - run: yarn build batch
+      - run: yarn build admin


### PR DESCRIPTION
## 바뀐점
yarn build를 수행해 test에서 확인하지 못하는 환경에서의 build 오류를 감지하도록함

## 바꾼이유
이전에 test는 통과하였으나 실제 서버 run시 오류가 발생함

## 설명
build뿐만 아니라 실행까지 해보면 좋을것 같은데 서버를 켰다가 정상작동을 확인하고 종료시키는 작업으로 동작시키는게 적절한 방법인지 의문입니다