### PR TITLE
Fix: makefile docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ dev-batch: ready
 
 .PHONY: clean
 clean:
-	docker-compose $(COMPOSE_FILE) down
+	docker-compose $(COMPOSE_FLAGS) down
 
 .PHONY: clean-all
 clean-all: clean

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test-api: test-ready
 deploy:
 	mkdir -p ./infra/db
 	cat ./infra/docker-compose.yml | head -n 1 > ./infra/docker-compose.stack.yml
-	docker-compose $(COMPOSE_FLAGS) convert --no-normalize >> ./infra/docker-compose.stack.yml
+	docker-compose $(COMPOSE_FLAGS) convert --no-normalize | grep -v platform >> ./infra/docker-compose.stack.yml
 	docker stack deploy $(SERVICE_NAME) -c ./infra/docker-compose.stack.yml
 	rm ./infra/docker-compose.stack.yml
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -63,6 +63,7 @@ services:
   db:
     image: mysql:5.7
     container_name: 42world-backend-db
+    platform: linux/x86_64
     ports:
       - '${DB_PORT}:3306'
     environment:


### PR DESCRIPTION
## 바뀐점
- makefile의 clean에 있는 오타 수정
- docker compose file의 db의 플랫폼을 따로 지정안해주면 m1에서 안돌아가는 문제 수정

## 바꾼이유

## 설명
- 추후 mysql8로 올리면 플랫폼 키워드 없어도 될거 같습니다
