### PR TITLE
Fix: cookie 옵션, alpha, prod일때 다르게 설정 및 옵션 추가

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -59,6 +59,6 @@ export class AuthController {
   @ApiOkResponse({ description: '로그아웃 성공' })
   @ApiUnauthorizedResponse({ description: '인증 실패' })
   signout(@Res({ passthrough: true }) response: Response): void {
-    response.clearCookie(process.env.ACCESS_TOKEN_KEY);
+    response.clearCookie(process.env.ACCESS_TOKEN_KEY, getCookieOption());
   }
 }

--- a/libs/utils/src/utils.ts
+++ b/libs/utils/src/utils.ts
@@ -25,8 +25,10 @@ export const isExpired = (exp: Date): boolean => {
 };
 
 export const getCookieOption = (): CookieOptions => {
-  if (process.env.NODE_ENV === 'alpha' || process.env.NODE_ENV === 'prod') {
-    return { secure: true, sameSite: 'none' };
+  if (process.env.NODE_ENV === 'prod') {
+    return { httpOnly: true, secure: true, sameSite: 'lax' };
+  } else if (process.env.NODE_ENV === 'alpha') {
+    return { httpOnly: true, secure: true, sameSite: 'none' };
   }
   return {};
 };


### PR DESCRIPTION
## 바뀐점
- cookie 옵션, alpha, prod일때 다르게 설정 및 옵션 추가
- httpOnly 옵션 추가
- sameSite prod일때는 lax로 변경
- clearCookie를 할때 쿠키 옵션을 사용하도록 추가

## 바꾼이유
- 쿠키를 자바스크립트로 조작할 수 없도록 httpOnly 옵션 적용
- alpha 일 경우 로컬에서 붙어서 작업할때 도메인이 다르다는 이유로 브라우저가 쿠키를 삭제하지 않아 sameSite=none 으로 설정
## 설명
