### PR TITLE
CORS origin 으로 regex 를 쓸수있도록 변경

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -42,6 +42,8 @@ async function bootstrap() {
     origin: [...originList.split(',').map((item) => item.trim()), originRegex],
     credentials: true,
   });
+  console.log(`CORS origin: ${[...originList.split(',').map((item) => item.trim()), originRegex]}`);
+
   app.useGlobalFilters(new HttpExceptionFilter());
   app.useGlobalPipes(
     new ValidationPipe({

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -37,8 +37,9 @@ async function bootstrap() {
   });
 
   const originList = process.env.ORIGIN_LIST || '';
+  const originRegex = process.env.ORIGIN_REGEX ? new RegExp(process.env.ORIGIN_REGEX) : '';
   app.enableCors({
-    origin: originList.split(',').map((item) => item.trim()),
+    origin: [...originList.split(',').map((item) => item.trim()), originRegex],
     credentials: true,
   });
   app.useGlobalFilters(new HttpExceptionFilter());

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -42,8 +42,6 @@ async function bootstrap() {
     origin: [...originList.split(',').map((item) => item.trim()), originRegex],
     credentials: true,
   });
-  console.log(`CORS origin: ${[...originList.split(',').map((item) => item.trim()), originRegex]}`);
-
   app.useGlobalFilters(new HttpExceptionFilter());
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
## 바뀐점
front 에서 amplify 배포시 cors 에러를 regex 로 해결하기 위해 env 하나 추가했습니다.

## 바꾼이유

## 설명
