### PR TITLE
Refactor: mail module

### DIFF
--- a/apps/api/src/intra-auth/intra-auth.module.ts
+++ b/apps/api/src/intra-auth/intra-auth.module.ts
@@ -1,30 +1,16 @@
+import { MailModule } from '@api/mail/mail.module';
 import { UserModule } from '@api/user/user.module';
 import { CacheModule } from '@app/common/cache/cache.module';
 import { IntraAuth } from '@app/entity/intra-auth/intra-auth.entity';
 import { Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { IntraAuthController } from './intra-auth.controller';
 import { IntraAuthService } from './intra-auth.service';
-import StibeeService from './stibee.service';
 
 @Module({
-  imports: [UserModule, CacheModule, TypeOrmModule.forFeature([IntraAuth]), ConfigModule],
+  imports: [UserModule, CacheModule, TypeOrmModule.forFeature([IntraAuth]), ConfigModule, MailModule],
   controllers: [IntraAuthController],
-  providers: [
-    IntraAuthService,
-    {
-      provide: 'MailService',
-      inject: [ConfigService],
-      useFactory: async (config: ConfigService) => {
-        return new StibeeService(config);
-      },
-    },
-    {
-      provide: 'UnsubscribeStibeeService',
-      useClass: StibeeService,
-    },
-  ],
-  exports: [IntraAuthService],
+  providers: [IntraAuthService],
 })
 export class IntraAuthModule {}

--- a/apps/api/src/intra-auth/intra-auth.service.ts
+++ b/apps/api/src/intra-auth/intra-auth.service.ts
@@ -1,8 +1,11 @@
 import {
   CADET_ALREADY_EXIST_ERROR_MESSAGE,
+  EMAIL,
   NOT_EXIST_TOKEN_ERROR_MESSAGE,
   SIGNIN_ALREADY_AUTH_ERROR_MESSAGE,
 } from '@api/intra-auth/intra-auth.constant';
+import { MailService, MailServiceToken } from '@api/mail/mail.service';
+import { UnsubscribeStibeeService, UnsubscribeStibeeServiceToken } from '@api/mail/unsubscribe-stibee.service';
 import { UserService } from '@api/user/user.service';
 import { CacheService } from '@app/common/cache/cache.service';
 import { IntraAuthMailDto } from '@app/common/cache/dto/intra-auth.dto';
@@ -13,15 +16,18 @@ import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { getCode } from './intra-auth.utils';
-import MailService from './mail.service';
-import UnsubscribeStibeeService from './unsubscribe-stibee.service';
 
 @Injectable()
 export class IntraAuthService {
   constructor(
-    @Inject('MailService') private readonly mailService: MailService,
-    @Inject('UnsubscribeStibeeService') private readonly unsubscribeStibeeService: UnsubscribeStibeeService,
+    @Inject(MailServiceToken)
+    private readonly mailService: MailService,
+
+    @Inject(UnsubscribeStibeeServiceToken)
+    private readonly unsubscribeStibeeService: UnsubscribeStibeeService,
+
     private readonly userService: UserService,
+
     private readonly cacheService: CacheService,
 
     @InjectRepository(IntraAuth)
@@ -40,7 +46,7 @@ export class IntraAuthService {
 
     await this.cacheService.setIntraAuthMailData(code, intraAuthMailDto);
 
-    await this.mailService.send(intraId, code, user.nickname);
+    await this.mailService.send(intraId, `${intraId}@${EMAIL}`, code, user.nickname);
   }
 
   async getAuth(code: string): Promise<void | never> {

--- a/apps/api/src/intra-auth/intra-auth.service.ts
+++ b/apps/api/src/intra-auth/intra-auth.service.ts
@@ -4,7 +4,7 @@ import {
   NOT_EXIST_TOKEN_ERROR_MESSAGE,
   SIGNIN_ALREADY_AUTH_ERROR_MESSAGE,
 } from '@api/intra-auth/intra-auth.constant';
-import { MailService, MailServiceToken } from '@api/mail/mail.service';
+import { MailService, MAIL_SERVICE_TOKEN } from '@api/mail/mail.service';
 import { UnsubscribeStibeeService, UnsubscribeStibeeServiceToken } from '@api/mail/unsubscribe-stibee.service';
 import { UserService } from '@api/user/user.service';
 import { CacheService } from '@app/common/cache/cache.service';
@@ -20,7 +20,7 @@ import { getCode } from './intra-auth.utils';
 @Injectable()
 export class IntraAuthService {
   constructor(
-    @Inject(MailServiceToken)
+    @Inject(MAIL_SERVICE_TOKEN)
     private readonly mailService: MailService,
 
     @Inject(UnsubscribeStibeeServiceToken)

--- a/apps/api/src/intra-auth/intra-auth.service.ts
+++ b/apps/api/src/intra-auth/intra-auth.service.ts
@@ -46,7 +46,7 @@ export class IntraAuthService {
 
     await this.cacheService.setIntraAuthMailData(code, intraAuthMailDto);
 
-    await this.mailService.send(intraId, `${intraId}@${EMAIL}`, code, user.nickname);
+    await this.mailService.send(`${intraId}@${EMAIL}`, intraId, code, user.nickname);
   }
 
   async getAuth(code: string): Promise<void | never> {

--- a/apps/api/src/intra-auth/mail.service.ts
+++ b/apps/api/src/intra-auth/mail.service.ts
@@ -1,3 +1,0 @@
-export default interface MailService {
-  send(name: string, code: string, githubId: string);
-}

--- a/apps/api/src/intra-auth/unsubscribe-stibee.service.ts
+++ b/apps/api/src/intra-auth/unsubscribe-stibee.service.ts
@@ -1,3 +1,0 @@
-export default interface UnsubscribeStibeeService {
-  unsubscribe(name: string);
-}

--- a/apps/api/src/mail/mail.module.ts
+++ b/apps/api/src/mail/mail.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { MailServiceToken } from './mail.service';
+import { MAIL_SERVICE_TOKEN } from './mail.service';
 import StibeeService from './stibee.service';
 import { UnsubscribeStibeeServiceToken } from './unsubscribe-stibee.service';
 
 @Module({
   providers: [
     {
-      provide: MailServiceToken,
+      provide: MAIL_SERVICE_TOKEN,
       inject: [ConfigService],
       useFactory: async (config: ConfigService) => {
         return new StibeeService(config);
@@ -18,6 +18,6 @@ import { UnsubscribeStibeeServiceToken } from './unsubscribe-stibee.service';
       useClass: StibeeService,
     },
   ],
-  exports: [MailServiceToken, UnsubscribeStibeeServiceToken],
+  exports: [MAIL_SERVICE_TOKEN, UnsubscribeStibeeServiceToken],
 })
 export class MailModule {}

--- a/apps/api/src/mail/mail.module.ts
+++ b/apps/api/src/mail/mail.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { MailServiceToken } from './mail.service';
+import StibeeService from './stibee.service';
+import { UnsubscribeStibeeServiceToken } from './unsubscribe-stibee.service';
+
+@Module({
+  providers: [
+    {
+      provide: MailServiceToken,
+      inject: [ConfigService],
+      useFactory: async (config: ConfigService) => {
+        return new StibeeService(config);
+      },
+    },
+    {
+      provide: UnsubscribeStibeeServiceToken,
+      useClass: StibeeService,
+    },
+  ],
+  exports: [MailServiceToken, UnsubscribeStibeeServiceToken],
+})
+export class MailModule {}

--- a/apps/api/src/mail/mail.service.ts
+++ b/apps/api/src/mail/mail.service.ts
@@ -1,4 +1,4 @@
-export const MailServiceToken = Symbol('MailService');
+export const MAIL_SERVICE_TOKEN = Symbol('MailService');
 
 export interface MailService {
   send(name: string, email: string, code: string, githubId: string);

--- a/apps/api/src/mail/mail.service.ts
+++ b/apps/api/src/mail/mail.service.ts
@@ -1,0 +1,5 @@
+export const MailServiceToken = Symbol('MailService');
+
+export interface MailService {
+  send(name: string, email: string, code: string, githubId: string);
+}

--- a/apps/api/src/mail/stibee.service.ts
+++ b/apps/api/src/mail/stibee.service.ts
@@ -11,10 +11,14 @@ export default class StibeeService implements MailService, UnsubscribeStibeeServ
 
   private accessToken = this.configService.get<string>('STIBEE_API_KEY');
 
-  async send(name: string, email: string, code: string, githubId: string) {
+  async send(email: string, name: string, code: string, githubId: string) {
     await this.subscribe(name);
-    const url = this.configService.get('STIBEE_MAIL_SEND_URL');
+    const url = this.configService.get<string>('STIBEE_MAIL_SEND_URL');
 
+    await this.mailSend(url, email, name, code, githubId);
+  }
+
+  private async mailSend(url: string, email: string, name: string, code: string, githubId: string) {
     try {
       await axios.post(
         url,

--- a/apps/api/src/mail/stibee.service.ts
+++ b/apps/api/src/mail/stibee.service.ts
@@ -1,16 +1,17 @@
+import { logger } from '@app/utils/logger';
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import axios from 'axios';
-import { EMAIL } from './intra-auth.constant';
-import MailService from './mail.service';
-import UnsubscribeStibeeService from './unsubscribe-stibee.service';
+import { MailService } from './mail.service';
+import { UnsubscribeStibeeService } from './unsubscribe-stibee.service';
+
 @Injectable()
 export default class StibeeService implements MailService, UnsubscribeStibeeService {
   constructor(private readonly configService: ConfigService) {}
 
   private accessToken = this.configService.get<string>('STIBEE_API_KEY');
 
-  async send(name: string, code: string, githubId: string) {
+  async send(name: string, email: string, code: string, githubId: string) {
     await this.subscribe(name);
     const url = this.configService.get('STIBEE_MAIL_SEND_URL');
 
@@ -18,7 +19,7 @@ export default class StibeeService implements MailService, UnsubscribeStibeeServ
       await axios.post(
         url,
         {
-          subscriber: `${name}@${EMAIL}`,
+          subscriber: email,
           name,
           code,
           githubId,
@@ -67,7 +68,7 @@ export default class StibeeService implements MailService, UnsubscribeStibeeServ
   }
 
   private printError(err: any) {
-    console.error({ status: err.response.status, message: err.response.data });
-    console.trace();
+    logger.error({ status: err.response.status, message: err.response.data });
+    logger.error(err.stack);
   }
 }

--- a/apps/api/src/mail/unsubscribe-stibee.service.ts
+++ b/apps/api/src/mail/unsubscribe-stibee.service.ts
@@ -1,0 +1,5 @@
+export const UnsubscribeStibeeServiceToken = Symbol('UnsubscribeStibee');
+
+export interface UnsubscribeStibeeService {
+  unsubscribe(name: string);
+}

--- a/apps/api/test/e2e/intra-auth.e2e-spec.ts
+++ b/apps/api/test/e2e/intra-auth.e2e-spec.ts
@@ -2,7 +2,7 @@ import { AuthModule } from '@api/auth/auth.module';
 import { AuthService } from '@api/auth/auth.service';
 import { IntraAuthController } from '@api/intra-auth/intra-auth.controller';
 import { IntraAuthService } from '@api/intra-auth/intra-auth.service';
-import { MailServiceToken } from '@api/mail/mail.service';
+import { MAIL_SERVICE_TOKEN } from '@api/mail/mail.service';
 import StibeeService from '@api/mail/stibee.service';
 import { UnsubscribeStibeeServiceToken } from '@api/mail/unsubscribe-stibee.service';
 import { UserRepository } from '@api/user/repositories/user.repository';
@@ -44,7 +44,7 @@ describe('IntraAuth', () => {
       providers: [
         IntraAuthService,
         {
-          provide: MailServiceToken,
+          provide: MAIL_SERVICE_TOKEN,
           useValue: instance(stibeeService),
         },
         {

--- a/apps/api/test/e2e/intra-auth.e2e-spec.ts
+++ b/apps/api/test/e2e/intra-auth.e2e-spec.ts
@@ -2,7 +2,9 @@ import { AuthModule } from '@api/auth/auth.module';
 import { AuthService } from '@api/auth/auth.service';
 import { IntraAuthController } from '@api/intra-auth/intra-auth.controller';
 import { IntraAuthService } from '@api/intra-auth/intra-auth.service';
-import StibeeService from '@api/intra-auth/stibee.service';
+import { MailServiceToken } from '@api/mail/mail.service';
+import StibeeService from '@api/mail/stibee.service';
+import { UnsubscribeStibeeServiceToken } from '@api/mail/unsubscribe-stibee.service';
 import { UserRepository } from '@api/user/repositories/user.repository';
 import { UserModule } from '@api/user/user.module';
 import { CacheService } from '@app/common/cache/cache.service';
@@ -42,11 +44,11 @@ describe('IntraAuth', () => {
       providers: [
         IntraAuthService,
         {
-          provide: 'MailService',
+          provide: MailServiceToken,
           useValue: instance(stibeeService),
         },
         {
-          provide: 'UnsubscribeStibeeService',
+          provide: UnsubscribeStibeeServiceToken,
           useValue: instance(stibeeService),
         },
         {


### PR DESCRIPTION
## 바뀐점
- MailService를 MailModule로 이전

## 바꾼이유
- intra-auth 모듈에 있을 기능이 아니기 때문에 별도의 모듈로 분리
- 추후 스티비 api가 아니게 되더라도 mail moudle을 수정하면 되기때문에
   - unsubscribeStibeeService가 intra-auth에서 호출되고 있어서 메일 전송하는 시점에 구독 후 해지를 전부 할 지 고민중

## 설명
