### PR TITLE
feat: mysql 5.7에서 8.0으로 docker-compose 버전업

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -61,9 +61,8 @@ services:
         order: start-first
   #-----------------------------------------------------------------------------------
   db:
-    image: mysql:5.7
+    image: mysql:8.0
     container_name: 42world-backend-db
-    platform: linux/x86_64
     ports:
       - '${DB_PORT}:3306'
     environment:

--- a/infra/run_test_db.sh
+++ b/infra/run_test_db.sh
@@ -2,7 +2,6 @@
 
 if ! $( docker container inspect -f '{{.State.Running}}' ft_world-mysql-test 2> /dev/null ); then
     docker run -d --rm --name ft_world-mysql-test \
-        --platform linux/x86_64 \
         -e MYSQL_DATABASE=ft_world \
         -e MYSQL_USER=ft_world \
         -e MYSQL_PASSWORD=ft_world \
@@ -14,6 +13,6 @@ if ! $( docker container inspect -f '{{.State.Running}}' ft_world-mysql-test 2> 
         --health-start-period=0s \
         --health-timeout=1s \
         -e TZ=Asia/Seoul \
-        -p 3308:3306 mysql:5.7 \
+        -p 3308:3306 mysql:8.0 \
         mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
 fi


### PR DESCRIPTION
## 바뀐점

docker-compose 에서 mysql기존 5.7에서 8.0로 업그레이드 했습니다.
mysql 5.7 은 arm 버전이 없었는데, mysql 8.0은 arm 버전이 있어서 platfrom 을 따로 지정안해줘도 됩니다. (m1 만세!)

## 바꾼이유

mysql 5.7 은 정규식을 미지원했기 때문에 정규식을 지원하는 8.0 으로 업그레이드 합니다.

## 설명
