### PR TITLE
CI: auto label in issue

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,14 @@
+name: 'Auto Label'
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Yaminyam/auto-label-in-issue@1.1.0


### PR DESCRIPTION
## 바뀐점
issue에 달려있는 label들을 자동으로 연결된 pull_request 에도 할당

## 바꾼이유
귀찮게 한번더 pull_request에 label을 할당할 필요가 없음
그리고 오픈소스인 만큼 해당 레포에 권한이 없는 사용자는 label을 할당할 권한이 없음

## 설명
