### PR TITLE
refactor: article service 의존을 article api service 로

### DIFF
--- a/apps/api/src/article/article-api.module.ts
+++ b/apps/api/src/article/article-api.module.ts
@@ -7,7 +7,12 @@ import { ArticleApiController } from './article-api.controller';
 import { ArticleApiService } from './article-api.service';
 
 @Module({
-  imports: [ArticleModule, CategoryModule, ReactionModule, CommentModule],
+  imports: [
+    ArticleModule, //
+    CategoryModule,
+    ReactionModule,
+    CommentModule,
+  ],
   providers: [ArticleApiService],
   controllers: [ArticleApiController],
 })

--- a/apps/api/src/article/article-api.service.ts
+++ b/apps/api/src/article/article-api.service.ts
@@ -1,67 +1,41 @@
+import { ArticleService } from '@api/article/article.service';
 import { CategoryService } from '@api/category/category.service';
+import { CommentService } from '@api/comment/comment.service';
+import { ReactionService } from '@api/reaction/reaction.service';
 import { Article } from '@app/entity/article/article.entity';
+import { Category } from '@app/entity/category/category.entity';
+import { Comment } from '@app/entity/comment/comment.entity';
+import { ReactionComment } from '@app/entity/reaction/reaction-comment.entity';
 import { UserRole } from '@app/entity/user/interfaces/userrole.interface';
 import { User } from '@app/entity/user/user.entity';
-import { ForbiddenException, Injectable } from '@nestjs/common';
+import { compareRole } from '@app/utils/utils';
+import { Injectable } from '@nestjs/common';
 import { PaginationRequestDto } from '../pagination/dto/pagination-request.dto';
-import { ArticleRepository } from './repositories/article.repository';
 
 @Injectable()
 export class ArticleApiService {
   constructor(
-    private readonly articleRepository: ArticleRepository,
+    private readonly articleService: ArticleService, //
+    private readonly reactionService: ReactionService,
+    private readonly commentService: CommentService,
     private readonly categoryService: CategoryService,
   ) {}
 
   async create(writer: User, title: string, content: string, categoryId: number): Promise<Article> {
     await this.categoryService.checkAvailable(writer, categoryId, 'writableArticle');
 
-    const { id } = await this.articleRepository.save({
-      title,
-      content,
-      categoryId,
-      writerId: writer.id,
-    });
-
-    return await this.articleRepository.findOneOrFail(id, {
-      relations: ['writer', 'category'],
-    });
+    return await this.articleService.create(writer, title, content, categoryId);
   }
 
   async search(
     user: User,
     q: string,
-    categoryId: number,
+    categoryId: number | undefined,
     options: PaginationRequestDto,
   ): Promise<{ articles: Article[]; totalCount: number }> {
     const availableCategories = await this.categoryService.getAvailable(user);
 
-    let availableCategoryIds = availableCategories.map((category) => category.id);
-
-    if (categoryId) {
-      if (!availableCategoryIds.some((availableCategoryId) => availableCategoryId === categoryId)) {
-        throw new ForbiddenException(`Category ${categoryId} is not available`);
-      }
-      availableCategoryIds = [categoryId];
-    }
-
-    return await this.articleRepository.search(q, availableCategoryIds, options);
-  }
-
-  async findOneById(user: User, id: number): Promise<Article> {
-    const article = await this.articleRepository.findOneOrFail(id, {
-      relations: ['writer', 'category'],
-    });
-
-    await this.categoryService.checkAvailable(user, article.categoryId, 'readableArticle');
-
-    if (article.writerId !== user.id) {
-      await this.articleRepository.update(id, {
-        viewCount: () => 'view_count + 1',
-      });
-    }
-
-    return article;
+    return await this.articleService.search(q, categoryId, options, availableCategories);
   }
 
   async findAllByCategoryId(
@@ -71,44 +45,53 @@ export class ArticleApiService {
   ): Promise<{ articles: Article[]; totalCount: number }> {
     await this.categoryService.checkAvailable(user, categoryId, 'readableArticle');
 
-    return await this.articleRepository.findAllByCategoryId(categoryId, options);
+    return await this.articleService.findAllByCategoryId(categoryId, options);
+  }
+
+  async findOneById(user: User, articleId: number): Promise<{ article: Article; isLike: boolean }> {
+    const article = await this.articleService.findOneById(user, articleId);
+    const isLike = await this.reactionService.isMyReactionArticle(user.id, article.id);
+
+    await this.categoryService.checkAvailable(user, article.categoryId, 'readableArticle');
+    await this.articleService.increaseViewCount(user, article);
+
+    return { article, isLike };
+  }
+
+  async getComments(
+    user: User,
+    articleId: number,
+    options: PaginationRequestDto,
+  ): Promise<{
+    comments: Comment[];
+    reactionComments: ReactionComment[];
+    category: Category;
+    totalCount: number;
+  }> {
+    const { comments, category, totalCount } = await this.commentService.findAllByArticleId(user, articleId, options);
+    let reactionComments = [];
+    if (compareRole(category.reactionable as UserRole, user.role as UserRole))
+      reactionComments = await this.reactionService.findAllMyReactionComment(user.id, articleId);
+
+    return { comments, category, totalCount, reactionComments };
   }
 
   async update(
     user: User,
     id: number,
-    title: string | null,
-    content: string | null,
-    categoryId: number | null,
+    title: string | undefined,
+    content: string | undefined,
+    categoryId: number | undefined,
   ): Promise<void> {
-    const article = await this.articleRepository.findOneOrFail(id);
-
-    if (article.writerId !== user.id && user.role !== UserRole.ADMIN) {
-      throw new ForbiddenException('권한이 없습니다');
-    }
-
+    // TODO: categoryId를 확인하는 로직을 지워야함
     if (categoryId) {
-      if (user.role !== UserRole.ADMIN) {
-        throw new ForbiddenException('권한이 없습니다');
-      }
-
       await this.categoryService.checkAvailable(user, categoryId, 'writableArticle');
     }
 
-    await this.articleRepository.update(id, {
-      title: title ?? article.title,
-      content: content ?? article.content,
-      categoryId: categoryId ?? article.categoryId,
-    });
+    await this.articleService.update(user, id, title, content, categoryId);
   }
 
   async remove(user: User, id: number): Promise<void> {
-    const article = await this.articleRepository.findOneOrFail(id);
-
-    if (article.writerId !== user.id && user.role !== UserRole.ADMIN) {
-      throw new ForbiddenException('권한이 없습니다');
-    }
-
-    await this.articleRepository.softDelete(id);
+    await this.articleService.remove(user, id);
   }
 }

--- a/apps/api/src/article/article.module.ts
+++ b/apps/api/src/article/article.module.ts
@@ -4,8 +4,10 @@ import { ArticleService } from './article.service';
 import { ArticleRepository } from './repositories/article.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ArticleRepository])],
+  imports: [
+    TypeOrmModule.forFeature([ArticleRepository]), //
+  ],
   providers: [ArticleService],
-  exports: [ArticleService, TypeOrmModule],
+  exports: [ArticleService],
 })
 export class ArticleModule {}

--- a/apps/api/src/article/article.service.ts
+++ b/apps/api/src/article/article.service.ts
@@ -1,11 +1,60 @@
 import { PaginationRequestDto } from '@api/pagination/dto/pagination-request.dto';
 import { Article } from '@app/entity/article/article.entity';
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { Category } from '@app/entity/category/category.entity';
+import { UserRole } from '@app/entity/user/interfaces/userrole.interface';
+import { User } from '@app/entity/user/user.entity';
+import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
 import { ArticleRepository } from './repositories/article.repository';
 
 @Injectable()
 export class ArticleService {
   constructor(private readonly articleRepository: ArticleRepository) {}
+
+  async create(writer: User, title: string, content: string, categoryId: number): Promise<Article> {
+    const { id } = await this.articleRepository.save({
+      title,
+      content,
+      categoryId,
+      writerId: writer.id,
+    });
+
+    return await this.articleRepository.findOneOrFail(id, {
+      relations: ['writer', 'category'],
+    });
+  }
+
+  async search(
+    q: string,
+    categoryId: number | undefined,
+    options: PaginationRequestDto,
+    availableCategories: Category[],
+  ): Promise<{ articles: Article[]; totalCount: number }> {
+    let availableCategoryIds = availableCategories.map((availableCategory) => availableCategory.id);
+
+    if (categoryId) {
+      if (!availableCategoryIds.some((availableCategoryId) => availableCategoryId === categoryId)) {
+        throw new ForbiddenException(`Category ${categoryId} is not available`);
+      }
+      availableCategoryIds = [categoryId];
+    }
+
+    return await this.articleRepository.search(q, availableCategoryIds, options);
+  }
+
+  async findAllByCategoryId(
+    categoryId: number,
+    options: PaginationRequestDto,
+  ): Promise<{ articles: Article[]; totalCount: number }> {
+    return await this.articleRepository.findAllByCategoryId(categoryId, options);
+  }
+
+  async findOneById(user: User, id: number): Promise<Article> {
+    const article = await this.articleRepository.findOneOrFail(id, {
+      relations: ['writer', 'category'],
+    });
+
+    return article;
+  }
 
   async findAllByWriterId(
     writerId: number,
@@ -20,6 +69,52 @@ export class ArticleService {
 
   async findOneByIdOrFail(id: number): Promise<Article> {
     return this.articleRepository.findOneOrFail(id);
+  }
+
+  async update(
+    user: User,
+    id: number,
+    title: string | undefined,
+    content: string | undefined,
+    categoryId: number | undefined,
+  ): Promise<void> {
+    const article = await this.articleRepository.findOneOrFail(id);
+
+    if (article.writerId !== user.id && user.role !== UserRole.ADMIN) {
+      throw new ForbiddenException('권한이 없습니다');
+    }
+
+    if (categoryId) {
+      if (user.role !== UserRole.ADMIN) {
+        throw new ForbiddenException('권한이 없습니다');
+      }
+    }
+
+    await this.articleRepository.update(id, {
+      title: title ?? article.title,
+      content: content ?? article.content,
+      categoryId: categoryId ?? article.categoryId,
+    });
+  }
+
+  async remove(user: User, id: number): Promise<void> {
+    const article = await this.articleRepository.findOneOrFail(id);
+
+    if (article.writerId !== user.id && user.role !== UserRole.ADMIN) {
+      throw new ForbiddenException('권한이 없습니다');
+    }
+
+    await this.articleRepository.softDelete(id);
+  }
+
+  async increaseViewCount(user: User, article: Article): Promise<void> {
+    if (article.writerId === user.id) {
+      return;
+    }
+
+    await this.articleRepository.update(article.id, {
+      viewCount: () => 'view_count + 1',
+    });
   }
 
   async increaseCommentCount(articleId: number): Promise<void> {

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -1,0 +1,11 @@
+// export type AwaitedObject<T> = {
+//   [P in keyof T]: T[P] extends Promise<infer U> ? U : T[P];
+// };
+
+// export type OmitByType<T, U> = Pick<T, { [K in keyof T]: T[K] extends U ? never : K }[keyof T]>;
+
+// export type ReadOnlyObject<T> = {
+//   readonly [P in keyof T]: T[P];
+// };
+
+// export type VO<T> = ReadOnlyObject<OmitByType<AwaitedObject<T>, Function>>;


### PR DESCRIPTION
## 바뀐점

* controller 에서는 article api service 만 의존
* article service 는 article repository 만 의존
* article api service 에서 다양한 service 를 합쳐서 호출함

기존에 article service 에서 다른 모든 서비스들을 의존해서 사용하고 있었습니다. 
article service는 aritcle repository 만 의존하도록 바꾸고 article api service 에서 다른 서비스들을 대신 호출해서 결과값을 넘겨주는 방식으로 바꿨습니다.

## 바꾼이유

* 분리된 모듈에서 의존성 관계를 명확히 합니다.

## 설명
아래와 같이 의존관계를 만들기 위해서 불필요한 의존 관계를 지웠습니다.
<img width="1784" alt="스크린샷 2022-10-22 오후 11 24 04" src="https://user-images.githubusercontent.com/46391729/197408638-55b4b0b8-b500-4d13-b5bc-ba43c8d84999.png">

따라서 controller 에서는 article api service 만 호출 하고, article api service 는 별다른 비지니스 로직 없이 서로 다른 service 만 호출하는 형태가 되어야할거같습니다.

근데 지금은 모든 비지니스 로직이 서비스에만 있다보니까, 뭔가 지금은 비지니스 로직이 article service, article api service 둘다 산재해 있는 코드가 되어버렸습니다.
특히, 애매하게 비지니스 로직 중간중간에 다른 서비스가 필요한경우가 좀 있었습니다 (서비스 사이에 의존이 강하게 되어있음)
예) 카테고리 수정 기능 : 게시글 가져오기(article repository) -> 카테고리 권한 확인(category service) -> 게시글 업데이트 -> 게시글 저장 (article repository)

만약 카테고리 권한 확인을 카테고리 도메인 객체에서 처리했다면 애매한 서비스 의존이 없을거 같더라구요
도메인 객체의 필요성과 비지니스가 도메인에서 돌아가야한다는걸 다시금 느꼈슴다...