### PR TITLE
feat: staging phase 추가

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -48,7 +48,7 @@ export class AuthService {
 
     if (PHASE === 'prod') {
       return { httpOnly: true, secure: true, sameSite: 'lax', maxAge };
-    } else if (PHASE === 'alpha') {
+    } else if (PHASE === 'alpha' || PHASE === 'staging') {
       return { httpOnly: true, secure: true, sameSite: 'none', maxAge };
     }
 

--- a/apps/api/src/getEnvFromSecretManager.ts
+++ b/apps/api/src/getEnvFromSecretManager.ts
@@ -6,17 +6,20 @@ export const getEnvFromSecretManager = async (): Promise<Record<string, string>>
     return {};
   }
 
-  const secret_name = `${PHASE}/rookies/api`;
+  const secretName = `${PHASE}/rookies/api`;
+
+  console.log(`[${new Date().toISOString()}] Fetch secret from ${secretName}...`);
 
   const client = new SecretsManagerClient({
     region: 'ap-northeast-2',
   });
   const response = await client.send(
     new GetSecretValueCommand({
-      SecretId: secret_name,
+      SecretId: secretName,
       VersionStage: 'AWSCURRENT', // VersionStage defaults to AWSCURRENT if unspecified
     }),
   );
+  console.log(`[${new Date().toISOString()}] Fetch secret from ${secretName}... Done!`);
 
   const secrets = JSON.parse(response.SecretString);
 

--- a/libs/common/src/database/database.module.ts
+++ b/libs/common/src/database/database.module.ts
@@ -1,3 +1,4 @@
+import { PHASE } from '@app/utils/phase';
 import { DynamicModule } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -26,7 +27,7 @@ export class DatabaseModule {
 
               synchronize: false,
               migrationsRun: true,
-              logging: configService.get('PHASE') === 'local',
+              logging: PHASE === 'dev',
 
               migrations: [__dirname + '/migrations/**/*{.ts,.js}'],
               cli: {

--- a/libs/utils/src/phase.ts
+++ b/libs/utils/src/phase.ts
@@ -1,8 +1,10 @@
-export type Phase = 'dev' | 'alpha' | 'prod' | 'test';
+export type Phase = 'dev' | 'alpha' | 'staging' | 'prod' | 'test';
 
 export const PHASE: Phase =
   process.env.PHASE === 'prod' //
     ? 'prod'
+    : process.env.PHASE === 'staging'
+    ? 'staging'
     : process.env.PHASE === 'alpha'
     ? 'alpha'
     : process.env.PHASE === 'test'

--- a/libs/utils/src/utils.ts
+++ b/libs/utils/src/utils.ts
@@ -23,7 +23,7 @@ export const errorHook = async (exceptionName: string, exceptionMessage: string,
   const slackMessage = `[${PHASE}] ${exceptionName}: ${exceptionMessage}`;
 
   try {
-    if (PHASE === 'prod' || PHASE === 'alpha') {
+    if (PHASE !== 'dev' && PHASE !== 'test') {
       await axios.post(slackHookUrl, { text: slackMessage });
     }
   } catch (e) {


### PR DESCRIPTION
## 바뀐점

지금 환경 구분이 3가지
dev : 백엔드 개발자가 로컬에서 띄우는 환경을 지칭함
alpha : alpha 환경에 올라가는 서버를 지칭함
prod : production 환경에 올라가는 서버를 지칭함
 
dev : 백엔드 개발자가 로컬에서 띄우는 환경을 지칭함
alpha : alpha 환경에 올라가는 서버를 지칭함 <- 요거를 프론트에서 로컬에서 개발할때 쓰는데-> 로그인시 redirection url 이 localhost로 되어있지 않고 alpha 로 되어있어서
-> 로컬에서 개발시 로그인부분이 애매한상황...
-> for_local 같은 새로운 phase 가 등장을 하거나
-> alpha 는 그냥 로컬 개발용으로 냅두고
-> staging 을 새로 파거나 (기존 alpha역할..?)
prod : production 환경에 올라가는 서버를 지칭함

따라서 다음과같이 바꿀에정
4가지
백엔드 개발 로컬용 - dev
프론트 개발 로컬용 - alpha
실제 테스트용 - staging
라이브용 - live

## 바꾼이유

## 설명
