### PR TITLE
Chore: ecs service deploy script

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+PHASE=${1:-alpha}
+
+aws ecs update-service --cluster Rookies-alpha-api --service Rookies-${PHASE}-api --task-definition Rookies-${PHASE}-api --force-new-deployment


### PR DESCRIPTION
## 바뀐점
- esc 배포 스크립트 추가

## 바꾼이유

## 설명
- 클러스터 이름은 지금은 alpha 하나에 다 넣어놔서 고정
- prodction은 아직 없음
- github action으로 이 스크립트를 실행시킬 예정이나 이 파일은 없애고 바로 ci에서 해도 됨