### PR TITLE
Feature: upgrade typeorm from 0.2.41 to 0.3.16

### DIFF
--- a/apps/api/src/article/article.module.ts
+++ b/apps/api/src/article/article.module.ts
@@ -4,10 +4,8 @@ import { ArticleService } from './article.service';
 import { ArticleRepository } from './repository/article.repository';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([ArticleRepository]), //
-  ],
-  providers: [ArticleService],
+  imports: [],
+  providers: [ArticleService, ArticleRepository],
   exports: [ArticleService],
 })
 export class ArticleModule {}

--- a/apps/api/src/article/article.service.ts
+++ b/apps/api/src/article/article.service.ts
@@ -18,7 +18,8 @@ export class ArticleService {
       writerId: writer.id,
     });
 
-    return await this.articleRepository.findOneOrFail(id, {
+    return await this.articleRepository.findOneOrFail({
+      where: { id },
       relations: ['writer', 'category'],
     });
   }
@@ -49,7 +50,8 @@ export class ArticleService {
   }
 
   async findOneById(user: User, id: number): Promise<Article> {
-    const article = await this.articleRepository.findOneOrFail(id, {
+    const article = await this.articleRepository.findOneOrFail({
+      where: { id },
       relations: ['writer', 'category'],
     });
 
@@ -68,7 +70,9 @@ export class ArticleService {
   }
 
   async findOneByIdOrFail(id: number): Promise<Article> {
-    return this.articleRepository.findOneOrFail(id);
+    return this.articleRepository.findOneOrFail({
+      where: { id },
+    });
   }
 
   async update(
@@ -78,7 +82,9 @@ export class ArticleService {
     content: string | undefined,
     categoryId: number | undefined,
   ): Promise<void> {
-    const article = await this.articleRepository.findOneOrFail(id);
+    const article = await this.articleRepository.findOneOrFail({
+      where: { id },
+    });
 
     if (article.writerId !== user.id && user.role !== UserRole.ADMIN) {
       throw new ForbiddenException('권한이 없습니다');
@@ -98,7 +104,9 @@ export class ArticleService {
   }
 
   async remove(user: User, id: number): Promise<void> {
-    const article = await this.articleRepository.findOneOrFail(id);
+    const article = await this.articleRepository.findOneOrFail({
+      where: { id },
+    });
 
     if (article.writerId !== user.id && user.role !== UserRole.ADMIN) {
       throw new ForbiddenException('권한이 없습니다');

--- a/apps/api/src/article/repository/article.repository.ts
+++ b/apps/api/src/article/repository/article.repository.ts
@@ -1,10 +1,14 @@
 import { PaginationRequestDto } from '@api/pagination/dto/pagination-request.dto';
 import { Article } from '@app/entity/article/article.entity';
 import { getPaginationSkip } from '@app/utils/utils';
-import { Brackets, EntityRepository, Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { Brackets, DataSource, Repository } from 'typeorm';
 
-@EntityRepository(Article)
+@Injectable()
 export class ArticleRepository extends Repository<Article> {
+  constructor(dataSource: DataSource) {
+    super(Article, dataSource.createEntityManager());
+  }
   async findAllByCategoryId(
     categoryId: number,
     options: PaginationRequestDto,

--- a/apps/api/src/category/category.module.ts
+++ b/apps/api/src/category/category.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { CategoryController } from './category.controller';
 import { CategoryService } from './category.service';
 import { CategoryRepository } from './repositories/category.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CategoryRepository])],
+  imports: [],
   controllers: [CategoryController],
-  providers: [CategoryService],
+  providers: [CategoryService, CategoryRepository],
   exports: [CategoryService],
 })
 export class CategoryModule {}

--- a/apps/api/src/category/category.service.ts
+++ b/apps/api/src/category/category.service.ts
@@ -26,7 +26,7 @@ export class CategoryService {
   }
 
   async findOneOrFail(id: number): Promise<Category | never> {
-    return this.categoryRepository.findOneOrFail(id);
+    return this.categoryRepository.findOneOrFail({ where: { id } });
   }
 
   async existOrFail(id: number): Promise<void | never> {
@@ -34,7 +34,7 @@ export class CategoryService {
   }
 
   async updateName(id: number, name: string): Promise<Category | never> {
-    const category = await this.categoryRepository.findOneOrFail(id);
+    const category = await this.categoryRepository.findOneOrFail({ where: { id } });
 
     category.name = name;
     return this.categoryRepository.save(category);

--- a/apps/api/src/category/repositories/category.repository.ts
+++ b/apps/api/src/category/repositories/category.repository.ts
@@ -1,10 +1,13 @@
 import { Category } from '@app/entity/category/category.entity';
 import { UserRole } from '@app/entity/user/interfaces/userrole.interface';
-import { NotFoundException } from '@nestjs/common';
-import { EntityRepository, Repository } from 'typeorm';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
 
-@EntityRepository(Category)
+@Injectable()
 export class CategoryRepository extends Repository<Category> {
+  constructor(dataSource: DataSource) {
+    super(Category, dataSource.createEntityManager());
+  }
   async existOrFail(id: number): Promise<void> {
     const existQuery = await this.query(`SELECT EXISTS
 		(SELECT * FROM category WHERE id=${id} AND deleted_at IS NULL)`);

--- a/apps/api/src/comment/comment.module.ts
+++ b/apps/api/src/comment/comment.module.ts
@@ -4,8 +4,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommentService } from './services/comment.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CommentRepository])],
-  providers: [CommentService],
+  imports: [],
+  providers: [CommentService, CommentRepository],
   exports: [CommentService],
 })
 export class CommentModule {}

--- a/apps/api/src/comment/repositories/comment.repository.ts
+++ b/apps/api/src/comment/repositories/comment.repository.ts
@@ -1,11 +1,14 @@
 import { PaginationRequestDto } from '@api/pagination/dto/pagination-request.dto';
 import { Comment } from '@app/entity/comment/comment.entity';
 import { getPaginationSkip } from '@app/utils/utils';
-import { NotFoundException } from '@nestjs/common';
-import { EntityRepository, Repository } from 'typeorm';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
 
-@EntityRepository(Comment)
+@Injectable()
 export class CommentRepository extends Repository<Comment> {
+  constructor(dataSource: DataSource) {
+    super(Comment, dataSource.createEntityManager());
+  }
   async findAllByArticleId(
     articleId: number,
     options: PaginationRequestDto,

--- a/apps/api/src/comment/services/comment.service.ts
+++ b/apps/api/src/comment/services/comment.service.ts
@@ -20,8 +20,8 @@ export class CommentService {
     return await this.commentRepository.findAllByArticleId(articleId, options);
   }
 
-  async findOneByIdOrFail(id: number, options?: FindOneOptions): Promise<Comment> {
-    return this.commentRepository.findOneOrFail(id, options);
+  async findOneByIdOrFail(id: number): Promise<Comment> {
+    return this.commentRepository.findOneOrFail({ where: { id } });
   }
 
   async findAllByWriterId(
@@ -35,7 +35,7 @@ export class CommentService {
   }
 
   async findByIdAndWriterIdOrFail(id: number, writerId: number): Promise<Comment> {
-    return this.commentRepository.findOneOrFail({ id, writerId });
+    return this.commentRepository.findOneOrFail({ where: { id, writerId } });
   }
 
   async save(comment: Comment): Promise<Comment> {

--- a/apps/api/src/intra-auth/intra-auth.service.ts
+++ b/apps/api/src/intra-auth/intra-auth.service.ts
@@ -65,7 +65,7 @@ export class IntraAuthService {
 
   private async checkExistCadet(intraId: string): Promise<void | never> {
     const cadet = await this.intraAuthRepository.findOne({
-      intraId: intraId,
+      where: { intraId },
     });
 
     if (cadet) {

--- a/apps/api/src/reaction/reaction.module.ts
+++ b/apps/api/src/reaction/reaction.module.ts
@@ -11,12 +11,12 @@ import { ReactionArticleRepository } from './repositories/reaction-article.repos
 @Module({
   imports: [
     CategoryModule,
-    TypeOrmModule.forFeature([ReactionArticleRepository, ReactionComment]),
+    TypeOrmModule.forFeature([ReactionComment]),
     forwardRef(() => ArticleModule),
     forwardRef(() => CommentModule),
   ],
   controllers: [ReactionController],
-  providers: [ReactionService],
-  exports: [ReactionService],
+  providers: [ReactionService, ReactionArticleRepository],
+  exports: [ReactionService, ReactionArticleRepository],
 })
 export class ReactionModule {}

--- a/apps/api/src/reaction/reaction.service.ts
+++ b/apps/api/src/reaction/reaction.service.ts
@@ -77,9 +77,7 @@ export class ReactionService {
     await this.categoryService.checkAvailable(user, article.categoryId, 'reactionable');
 
     const isReaction = await this.reactionCommentRepository.findOne({
-      userId,
-      commentId,
-      type,
+      where: { userId, commentId, type },
     });
     let isLike: boolean;
 
@@ -119,9 +117,7 @@ export class ReactionService {
     type: ReactionCommentType = ReactionCommentType.LIKE,
   ): Promise<ReactionComment[]> {
     return this.reactionCommentRepository.find({
-      userId,
-      articleId,
-      type,
+      where: { userId, articleId, type },
     });
   }
 

--- a/apps/api/src/reaction/repositories/reaction-article.repository.ts
+++ b/apps/api/src/reaction/repositories/reaction-article.repository.ts
@@ -1,10 +1,14 @@
 import { PaginationRequestDto } from '@api/pagination/dto/pagination-request.dto';
 import { ReactionArticle, ReactionArticleType } from '@app/entity/reaction/reaction-article.entity';
 import { getPaginationSkip } from '@app/utils/utils';
-import { EntityRepository, Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
 
-@EntityRepository(ReactionArticle)
+@Injectable()
 export class ReactionArticleRepository extends Repository<ReactionArticle> {
+  constructor(dataSource: DataSource) {
+    super(ReactionArticle, dataSource.createEntityManager());
+  }
   async isExist(userId: number, articleId: number, type: ReactionArticleType): Promise<boolean> {
     const existQuery = await this.query(`SELECT EXISTS
       (SELECT * FROM reaction_article WHERE user_id=${userId} AND article_id=${articleId} AND type='${type}')`);

--- a/apps/api/src/user/repositories/user.repository.ts
+++ b/apps/api/src/user/repositories/user.repository.ts
@@ -1,8 +1,12 @@
 import { User } from '@app/entity/user/user.entity';
-import { EntityRepository, Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
 
-@EntityRepository(User)
+@Injectable()
 export class UserRepository extends Repository<User> {
+  constructor(dataSource: DataSource) {
+    super(User, dataSource.createEntityManager());
+  }
   async isExistById(id: number): Promise<boolean> {
     const existQuery = await this.query(`SELECT EXISTS
 		(SELECT * FROM user WHERE id=${id} AND deleted_at IS NULL)`);

--- a/apps/api/src/user/user.module.ts
+++ b/apps/api/src/user/user.module.ts
@@ -14,10 +14,9 @@ import { UserService } from './user.service';
     ArticleModule,
     CommentModule,
     ReactionModule,
-    TypeOrmModule.forFeature([UserRepository]),
   ],
   controllers: [UserController],
-  providers: [UserService],
-  exports: [UserService, TypeOrmModule.forFeature([UserRepository])],
+  providers: [UserService, UserRepository],
+  exports: [UserService, UserRepository],
 })
 export class UserModule {}

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -17,7 +17,7 @@ export class UserService {
   }
 
   async findOneByIdOrFail(id: number): Promise<User | never> {
-    return this.userRepository.findOneOrFail(id);
+    return this.userRepository.findOneOrFail({ where: { id } });
   }
 
   async updateProfile(user: User, updateUserProfileDto: UpdateUserProfileRequestDto): Promise<User> {

--- a/apps/api/test/e2e/article.e2e-spec.ts
+++ b/apps/api/test/e2e/article.e2e-spec.ts
@@ -23,7 +23,7 @@ import { Test,TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { E2eTestBaseModule } from './e2e-test.base.module';
 import * as dummy from './utils/dummy';
-import { createTestApp } from './utils/utils';
+import { clearDB, createTestApp } from './utils/utils';
 import { testDto } from './utils/validate-test';
 import { DataSource } from 'typeorm';
 
@@ -65,9 +65,9 @@ describe('Article', () => {
     await httpServer.close();
   });
 
-  // beforeEach(async () => {
-  //   await clearDB();
-  // });
+  beforeEach(async () => {
+    await clearDB(dataSource);
+  });
 
   describe('/articles', () => {
     beforeEach(async () => {

--- a/apps/api/test/e2e/article.e2e-spec.ts
+++ b/apps/api/test/e2e/article.e2e-spec.ts
@@ -10,25 +10,26 @@ import { CategoryModule } from '@api/category/category.module';
 import { CategoryRepository } from '@api/category/repositories/category.repository';
 import { UserRepository } from '@api/user/repositories/user.repository';
 import {
-  ANONY_USER_CHARACTER,
-  ANONY_USER_DATE,
-  ANONY_USER_ID,
-  ANONY_USER_NICKNAME,
-  ANONY_USER_ROLE,
+ANONY_USER_CHARACTER,
+ANONY_USER_DATE,
+ANONY_USER_ID,
+ANONY_USER_NICKNAME,
+ANONY_USER_ROLE
 } from '@api/user/user.constant';
 import { UserModule } from '@api/user/user.module';
 import { Article } from '@app/entity/article/article.entity';
-import { HttpStatus, INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus,INestApplication } from '@nestjs/common';
+import { Test,TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { getConnection } from 'typeorm';
 import { E2eTestBaseModule } from './e2e-test.base.module';
 import * as dummy from './utils/dummy';
-import { clearDB, createTestApp } from './utils/utils';
+import { createTestApp } from './utils/utils';
 import { testDto } from './utils/validate-test';
+import { DataSource } from 'typeorm';
 
 describe('Article', () => {
   let httpServer: INestApplication;
+  let dataSource: DataSource;
 
   let userRepository: UserRepository;
   let articleRepository: ArticleRepository;
@@ -54,18 +55,19 @@ describe('Article', () => {
     categoryRepository = moduleFixture.get(CategoryRepository);
     authService = moduleFixture.get(AuthService);
 
+    dataSource = moduleFixture.get(DataSource);
     httpServer = app.getHttpServer();
   });
 
   afterAll(async () => {
-    await getConnection().dropDatabase();
-    await getConnection().close();
+    await dataSource.dropDatabase();
+    await dataSource.destroy();
     await httpServer.close();
   });
 
-  beforeEach(async () => {
-    await clearDB();
-  });
+  // beforeEach(async () => {
+  //   await clearDB();
+  // });
 
   describe('/articles', () => {
     beforeEach(async () => {

--- a/apps/api/test/e2e/article.e2e-spec.ts
+++ b/apps/api/test/e2e/article.e2e-spec.ts
@@ -412,7 +412,7 @@ describe('Article', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
       expect(response.status).toEqual(HttpStatus.OK);
 
-      const result = await articleRepository.findOne(articleId);
+      const result = await articleRepository.findOne({ where: { id: articleId } });
       expect(result.title).toBe(updateArticleRequestDto.title);
       expect(result.content).toBe(updateArticleRequestDto.content);
       expect(result.writerId).toBe(users.cadet[0].id);
@@ -439,7 +439,7 @@ describe('Article', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
       expect(response.status).toEqual(HttpStatus.FORBIDDEN);
 
-      const result = await articleRepository.findOne(articleId);
+      const result = await articleRepository.findOne({ where: { id: articleId } });
       expect(result.title).toBe(articles.second.title);
       expect(result.content).toBe(articles.second.content);
       expect(result.categoryId).toBe(articles.second.categoryId);
@@ -511,7 +511,7 @@ describe('Article', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
       expect(response.status).toEqual(HttpStatus.OK);
 
-      const result = await articleRepository.findOne(articleId);
+      const result = await articleRepository.findOne({ where: { id: articleId } });
       expect(result).toBeFalsy();
     });
 
@@ -531,7 +531,7 @@ describe('Article', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
       expect(response.status).toEqual(HttpStatus.FORBIDDEN);
 
-      const result = await articleRepository.findOne(articleId);
+      const result = await articleRepository.findOne({ where: { id: articleId } });
       expect(result).toBeTruthy();
     });
 
@@ -543,7 +543,7 @@ describe('Article', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
       expect(response.status).toEqual(HttpStatus.NOT_FOUND);
 
-      const result = await articleRepository.findOne(articleId);
+      const result = await articleRepository.findOne({ where: { id: articleId } });
       expect(result).toBeFalsy();
     });
 

--- a/apps/api/test/e2e/best.e2e-spec.ts
+++ b/apps/api/test/e2e/best.e2e-spec.ts
@@ -53,9 +53,9 @@ describe('Best', () => {
     await httpServer.close();
   });
 
-  // beforeEach(async () => {
-  //   await clearDB();
-  // });
+  beforeEach(async () => {
+    await clearDB(dataSource);
+  });
 
   describe('/best', () => {
     beforeEach(async () => {

--- a/apps/api/test/e2e/best.e2e-spec.ts
+++ b/apps/api/test/e2e/best.e2e-spec.ts
@@ -7,16 +7,17 @@ import { CategoryModule } from '@api/category/category.module';
 import { CategoryRepository } from '@api/category/repositories/category.repository';
 import { UserRepository } from '@api/user/repositories/user.repository';
 import { UserModule } from '@api/user/user.module';
-import { HttpStatus, INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus,INestApplication } from '@nestjs/common';
+import { Test,TestingModule } from '@nestjs/testing';
 import { E2eTestBaseModule } from '@test/e2e/e2e-test.base.module';
 import * as request from 'supertest';
-import { getConnection } from 'typeorm';
 import * as dummy from './utils/dummy';
-import { clearDB, createTestApp } from './utils/utils';
+import { clearDB,createTestApp } from './utils/utils';
+import { DataSource } from 'typeorm';
 
 describe('Best', () => {
   let httpServer: INestApplication;
+  let dataSource: DataSource;
 
   let userRepository: UserRepository;
   let articleRepository: ArticleRepository;
@@ -42,18 +43,19 @@ describe('Best', () => {
     categoryRepository = moduleFixture.get(CategoryRepository);
     authService = moduleFixture.get(AuthService);
 
+    dataSource = moduleFixture.get(DataSource);
     httpServer = app.getHttpServer();
   });
 
   afterAll(async () => {
-    await getConnection().dropDatabase();
-    await getConnection().close();
+    await dataSource.dropDatabase();
+    await dataSource.destroy();
     await httpServer.close();
   });
 
-  beforeEach(async () => {
-    await clearDB();
-  });
+  // beforeEach(async () => {
+  //   await clearDB();
+  // });
 
   describe('/best', () => {
     beforeEach(async () => {

--- a/apps/api/test/e2e/category.e2e-spec.ts
+++ b/apps/api/test/e2e/category.e2e-spec.ts
@@ -9,7 +9,7 @@ import { UserModule } from '@api/user/user.module';
 import { HttpStatus,INestApplication } from '@nestjs/common';
 import { Test,TestingModule } from '@nestjs/testing';
 import { E2eTestBaseModule } from '@test/e2e/e2e-test.base.module';
-import { createTestApp } from '@test/e2e/utils/utils';
+import { clearDB, createTestApp } from '@test/e2e/utils/utils';
 import * as request from 'supertest';
 import * as dummy from './utils/dummy';
 import { DataSource } from 'typeorm';
@@ -47,9 +47,9 @@ describe('Category', () => {
     await server.close();
   });
 
-  // beforeEach(async () => {
-  //   await clearDB();
-  // });
+  beforeEach(async () => {
+    await clearDB(dataSource);
+  });
 
   describe('/categories', () => {
     beforeEach(async () => {

--- a/apps/api/test/e2e/category.e2e-spec.ts
+++ b/apps/api/test/e2e/category.e2e-spec.ts
@@ -6,15 +6,16 @@ import { CategoryResponseDto } from '@api/category/dto/response/category-respons
 import { CategoryRepository } from '@api/category/repositories/category.repository';
 import { UserRepository } from '@api/user/repositories/user.repository';
 import { UserModule } from '@api/user/user.module';
-import { HttpStatus, INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus,INestApplication } from '@nestjs/common';
+import { Test,TestingModule } from '@nestjs/testing';
 import { E2eTestBaseModule } from '@test/e2e/e2e-test.base.module';
-import { clearDB, createTestApp } from '@test/e2e/utils/utils';
+import { createTestApp } from '@test/e2e/utils/utils';
 import * as request from 'supertest';
-import { getConnection } from 'typeorm';
 import * as dummy from './utils/dummy';
+import { DataSource } from 'typeorm';
 
 describe('Category', () => {
+  let dataSource: DataSource;
   let userRepository: UserRepository;
   let categoryRepository: CategoryRepository;
   let authService: AuthService;
@@ -36,18 +37,19 @@ describe('Category', () => {
     categoryRepository = moduleFixture.get(CategoryRepository);
     authService = moduleFixture.get(AuthService);
 
+    dataSource = moduleFixture.get(DataSource);
     server = app.getHttpServer();
   });
 
   afterAll(async () => {
-    await getConnection().dropDatabase();
-    await getConnection().close();
+    await dataSource.dropDatabase();
+    await dataSource.destroy();
     await server.close();
   });
 
-  beforeEach(async () => {
-    await clearDB();
-  });
+  // beforeEach(async () => {
+  //   await clearDB();
+  // });
 
   describe('/categories', () => {
     beforeEach(async () => {

--- a/apps/api/test/e2e/comment.e2e-spec.ts
+++ b/apps/api/test/e2e/comment.e2e-spec.ts
@@ -7,22 +7,23 @@ import { CategoryRepository } from '@api/category/repositories/category.reposito
 import { CommentApiModule } from '@api/comment/comment-api.module';
 import { CommentRepository } from '@api/comment/repositories/comment.repository';
 import { UserRepository } from '@api/user/repositories/user.repository';
-import { ANONY_USER_CHARACTER, ANONY_USER_ID, ANONY_USER_NICKNAME } from '@api/user/user.constant';
+import { ANONY_USER_CHARACTER,ANONY_USER_ID,ANONY_USER_NICKNAME } from '@api/user/user.constant';
 import { UserModule } from '@api/user/user.module';
 import { Article } from '@app/entity/article/article.entity';
 import { Comment } from '@app/entity/comment/comment.entity';
 import { User } from '@app/entity/user/user.entity';
-import { HttpStatus, INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus,INestApplication } from '@nestjs/common';
+import { Test,TestingModule } from '@nestjs/testing';
 import { E2eTestBaseModule } from '@test/e2e/e2e-test.base.module';
-import { clearDB, createTestApp } from '@test/e2e/utils/utils';
+import { clearDB,createTestApp } from '@test/e2e/utils/utils';
 import { testDto } from '@test/e2e/utils/validate-test';
 import * as request from 'supertest';
-import { getConnection } from 'typeorm';
 import * as dummy from './utils/dummy';
+import { DataSource } from 'typeorm';
 
 describe('Comments', () => {
   let httpServer: INestApplication;
+  let dataSource: DataSource;
   let userRepository: UserRepository;
   let authService: AuthService;
   let articleRepository: ArticleRepository;
@@ -59,18 +60,19 @@ describe('Comments', () => {
     commentRepository = moduleFixture.get(CommentRepository);
     authService = moduleFixture.get(AuthService);
 
+    dataSource = moduleFixture.get(DataSource);
     httpServer = app.getHttpServer();
   });
 
   afterAll(async () => {
-    await getConnection().dropDatabase();
-    await getConnection().close();
+    await dataSource.dropDatabase();
+    await dataSource.destroy();
     await httpServer.close();
   });
 
-  afterEach(async () => {
-    await clearDB();
-  });
+  // afterEach(async () => {
+  //   await clearDB();
+  // });
 
   beforeEach(async () => {
     users = await dummy.createDummyUsers(userRepository);

--- a/apps/api/test/e2e/comment.e2e-spec.ts
+++ b/apps/api/test/e2e/comment.e2e-spec.ts
@@ -70,9 +70,9 @@ describe('Comments', () => {
     await httpServer.close();
   });
 
-  // afterEach(async () => {
-  //   await clearDB();
-  // });
+  afterEach(async () => {
+    await clearDB(dataSource);
+  });
 
   beforeEach(async () => {
     users = await dummy.createDummyUsers(userRepository);

--- a/apps/api/test/e2e/image.e2e-spec.ts
+++ b/apps/api/test/e2e/image.e2e-spec.ts
@@ -48,10 +48,9 @@ describe('Image', () => {
       JWT = dummy.jwt(user, authService);
     });
 
-    // dropDataBase로 날아갈듯?
-    // afterEach(async () => {
-    //   await clearDB();
-    // });
+    afterEach(async () => {
+      await clearDB(dataSource);
+    });
 
     // TODO: S3 연동 수정할것!!
     test.skip('[성공] POST', async () => {

--- a/apps/api/test/e2e/image.e2e-spec.ts
+++ b/apps/api/test/e2e/image.e2e-spec.ts
@@ -9,7 +9,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { E2eTestBaseModule } from '@test/e2e/e2e-test.base.module';
 import { clearDB, createTestApp } from '@test/e2e/utils/utils';
 import * as request from 'supertest';
-import { getConnection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import * as dummy from './utils/dummy';
 
 describe('Image', () => {
@@ -18,6 +18,7 @@ describe('Image', () => {
   let authService: AuthService;
   let JWT: string;
   let users: dummy.DummyUsers;
+  let dataSource: DataSource;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -29,13 +30,14 @@ describe('Image', () => {
 
     userRepository = moduleFixture.get(UserRepository);
     authService = moduleFixture.get(AuthService);
+    dataSource = moduleFixture.get(DataSource);
 
     httpServer = app.getHttpServer();
   });
 
   afterAll(async () => {
-    await getConnection().dropDatabase();
-    await getConnection().close();
+    await dataSource.dropDatabase();
+    await dataSource.destroy();
     await httpServer.close();
   });
 
@@ -46,9 +48,10 @@ describe('Image', () => {
       JWT = dummy.jwt(user, authService);
     });
 
-    afterEach(async () => {
-      await clearDB();
-    });
+    // dropDataBase로 날아갈듯?
+    // afterEach(async () => {
+    //   await clearDB();
+    // });
 
     // TODO: S3 연동 수정할것!!
     test.skip('[성공] POST', async () => {

--- a/apps/api/test/e2e/intra-auth.e2e-spec.ts
+++ b/apps/api/test/e2e/intra-auth.e2e-spec.ts
@@ -14,7 +14,7 @@ import { HttpStatus,INestApplication } from '@nestjs/common';
 import { Test,TestingModule } from '@nestjs/testing';
 import { getRepositoryToken,TypeOrmModule } from '@nestjs/typeorm';
 import { E2eTestBaseModule } from '@test/e2e/e2e-test.base.module';
-import { createTestApp } from '@test/e2e/utils/utils';
+import { clearDB, createTestApp } from '@test/e2e/utils/utils';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import * as request from 'supertest';
@@ -88,9 +88,9 @@ describe('IntraAuth', () => {
       cadetJWT = dummy.jwt(cadetUser, authService);
     });
 
-    // afterEach(async () => {
-    //   await clearDB();
-    // });
+    afterEach(async () => {
+      await clearDB(dataSource);
+    });
 
     test('[성공] POST - 이메일 전송', async () => {
       const response = await request(httpServer)

--- a/apps/api/test/e2e/notification.e2e-spec.ts
+++ b/apps/api/test/e2e/notification.e2e-spec.ts
@@ -135,7 +135,7 @@ describe('Notification', () => {
         .set('Cookie', `${process.env.ACCESS_TOKEN_KEY}=${JWT}`);
       expect(res.status).toEqual(HttpStatus.OK);
       const readNotifications = await notificationRepository.find({
-        userId: dummyUser.id,
+        where: { userId: dummyUser.id }
       });
       expect(readNotifications.length).toEqual(2);
       expect(readNotifications[0].isRead).toEqual(true);

--- a/apps/api/test/e2e/notification.e2e-spec.ts
+++ b/apps/api/test/e2e/notification.e2e-spec.ts
@@ -18,7 +18,7 @@ import * as request from 'supertest';
 import { DataSource, Repository } from 'typeorm';
 import { E2eTestBaseModule } from './e2e-test.base.module';
 import * as dummy from './utils/dummy';
-import { createTestApp } from './utils/utils';
+import { clearDB, createTestApp } from './utils/utils';
 
 describe('Notification', () => {
   let httpServer: INestApplication;
@@ -60,9 +60,9 @@ describe('Notification', () => {
     await httpServer.close();
   });
 
-  // beforeEach(async () => {
-  //   await clearDB();
-  // });
+  beforeEach(async () => {
+    await clearDB(dataSource);
+  });
 
   describe('/notifications', () => {
     let dummyUser: User;

--- a/apps/api/test/e2e/notification.e2e-spec.ts
+++ b/apps/api/test/e2e/notification.e2e-spec.ts
@@ -15,13 +15,14 @@ import { HttpStatus, INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import * as request from 'supertest';
-import { getConnection, Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { E2eTestBaseModule } from './e2e-test.base.module';
 import * as dummy from './utils/dummy';
-import { clearDB, createTestApp } from './utils/utils';
+import { createTestApp } from './utils/utils';
 
 describe('Notification', () => {
   let httpServer: INestApplication;
+  let dataSource: DataSource;
 
   let userRepository: UserRepository;
   let categoryRepository: CategoryRepository;
@@ -49,18 +50,19 @@ describe('Notification', () => {
     notificationRepository = moduleFixture.get(getRepositoryToken(Notification));
     authService = moduleFixture.get(AuthService);
 
+    dataSource = moduleFixture.get(DataSource);
     httpServer = app.getHttpServer();
   });
 
   afterAll(async () => {
-    await getConnection().dropDatabase();
-    await getConnection().close();
+    await dataSource.dropDatabase();
+    await dataSource.destroy();
     await httpServer.close();
   });
 
-  beforeEach(async () => {
-    await clearDB();
-  });
+  // beforeEach(async () => {
+  //   await clearDB();
+  // });
 
   describe('/notifications', () => {
     let dummyUser: User;

--- a/apps/api/test/e2e/reaction.e2e-spec.ts
+++ b/apps/api/test/e2e/reaction.e2e-spec.ts
@@ -4,21 +4,21 @@ import { AuthModule } from '@api/auth/auth.module';
 import { AuthService } from '@api/auth/auth.service';
 import { CategoryModule } from '@api/category/category.module';
 import { CategoryRepository } from '@api/category/repositories/category.repository';
-import { CommentApiModule } from '@api/comment/comment-api.module';
 import { CommentRepository } from '@api/comment/repositories/comment.repository';
 import { ReactionModule } from '@api/reaction/reaction.module';
 import { UserRepository } from '@api/user/repositories/user.repository';
 import { UserModule } from '@api/user/user.module';
-import { HttpStatus, INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus,INestApplication } from '@nestjs/common';
+import { Test,TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { getConnection } from 'typeorm';
 import { E2eTestBaseModule } from './e2e-test.base.module';
 import * as dummy from './utils/dummy';
-import { clearDB, createTestApp } from './utils/utils';
+import { clearDB,createTestApp } from './utils/utils';
+import { DataSource } from 'typeorm';
 
 describe('Reaction', () => {
   let httpServer: INestApplication;
+  let dataSource: DataSource;
   let userRepository: UserRepository;
   let articleRepository: ArticleRepository;
   let categoryRepository: CategoryRepository;
@@ -50,18 +50,20 @@ describe('Reaction', () => {
     commentRepository = moduleFixture.get(CommentRepository);
     authService = moduleFixture.get(AuthService);
 
+    dataSource = moduleFixture.get(DataSource);
     httpServer = app.getHttpServer();
   });
 
   afterAll(async () => {
-    await getConnection().dropDatabase();
-    await getConnection().close();
+    console.log(dataSource);
+    await dataSource.dropDatabase();
+    await dataSource.destroy();
     await httpServer.close();
   });
 
-  beforeEach(async () => {
-    await clearDB();
-  });
+  // beforeEach(async () => {
+  //   await clearDB();
+  // });
 
   describe('/reactions/articles/{id}', () => {
     beforeEach(async () => {

--- a/apps/api/test/e2e/reaction.e2e-spec.ts
+++ b/apps/api/test/e2e/reaction.e2e-spec.ts
@@ -55,15 +55,14 @@ describe('Reaction', () => {
   });
 
   afterAll(async () => {
-    console.log(dataSource);
     await dataSource.dropDatabase();
     await dataSource.destroy();
     await httpServer.close();
   });
 
-  // beforeEach(async () => {
-  //   await clearDB();
-  // });
+  beforeEach(async () => {
+    await clearDB(dataSource);
+  });
 
   describe('/reactions/articles/{id}', () => {
     beforeEach(async () => {

--- a/apps/api/test/e2e/user.e2e-spec.ts
+++ b/apps/api/test/e2e/user.e2e-spec.ts
@@ -169,7 +169,7 @@ describe('User', () => {
 
       expect(response.status).toEqual(HttpStatus.OK);
 
-      const updatedUser = await userRepository.findOne(user.id);
+      const updatedUser = await userRepository.findOne({ where: { id: user.id } });
       expect(updatedUser.nickname).toEqual(updatedNickname);
       expect(updatedUser.character).toEqual(updatedCharacter);
     });
@@ -187,7 +187,7 @@ describe('User', () => {
 
       expect(response.status).toEqual(HttpStatus.OK);
 
-      const updatedUser = await userRepository.findOne(user.id);
+      const updatedUser = await userRepository.findOne({ where: { id: user.id } });
       expect(updatedUser.nickname).toEqual(user2.nickname);
       expect(updatedUser.character).toEqual(updatedCharacter);
     });
@@ -217,7 +217,7 @@ describe('User', () => {
 
       expect(response.status).toEqual(HttpStatus.OK);
 
-      const updatedUser = await userRepository.findOne(user.id);
+      const updatedUser = await userRepository.findOne({ where: { id: user.id }});
       expect(updatedUser.nickname).toEqual(updatedNickname);
       expect(updatedUser.character).toEqual(user.character);
     });
@@ -233,7 +233,7 @@ describe('User', () => {
 
       expect(response.status).toEqual(HttpStatus.OK);
 
-      const updatedUser = await userRepository.findOne(user.id);
+      const updatedUser = await userRepository.findOne({ where: { id: user.id }});
       expect(updatedUser.nickname).toEqual(user.nickname);
       expect(updatedUser.character).toEqual(updatedCharacter);
     });
@@ -250,7 +250,7 @@ describe('User', () => {
 
       expect(response.status).toEqual(HttpStatus.BAD_REQUEST);
 
-      const updatedUser = await userRepository.findOne(user.id);
+      const updatedUser = await userRepository.findOne({ where: { id: user.id }});
       expect(updatedUser.nickname).toEqual(user.nickname);
       expect(updatedUser.character).toEqual(user.character);
     });
@@ -262,9 +262,7 @@ describe('User', () => {
 
       expect(response.status).toEqual(HttpStatus.OK);
 
-      const deletedUser = await userRepository.findOne(user.id, {
-        withDeleted: true,
-      });
+      const deletedUser = await userRepository.findOne({ where: { id: user.id }, withDeleted: true });
 
       expect(deletedUser.deletedAt).toBeTruthy();
     });
@@ -333,7 +331,7 @@ describe('User', () => {
     });
 
     test('[성공] - GET - 내가 작성한 댓글 가져오기, 삭제한 게시글이 있는 경우', async () => {
-      await articleRepository.softDelete(articles.first);
+      await articleRepository.softDelete(articles.first.id);
 
       const response = await request(httpServer)
         .get('/users/me/comments')
@@ -385,7 +383,7 @@ describe('User', () => {
     });
 
     test('[성공] - GET - 내가 좋아요 누른 게시글 가져오기, 삭제한 게시글이 있는 경우', async () => {
-      await articleRepository.softDelete(articles.first);
+      await articleRepository.softDelete(articles.first.id);
 
       const response = await request(httpServer)
         .get('/users/me/like-articles')

--- a/apps/api/test/e2e/user.e2e-spec.ts
+++ b/apps/api/test/e2e/user.e2e-spec.ts
@@ -24,12 +24,12 @@ import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
 import * as dummy from '@test/e2e/utils/dummy';
 import { clearDB, createTestApp } from '@test/e2e/utils/utils';
 import * as request from 'supertest';
-import { getConnection, Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { E2eTestBaseModule } from './e2e-test.base.module';
-import {CommentModule} from "@api/comment/comment.module";
 
 describe('User', () => {
   let httpServer: INestApplication;
+  let dataSource: DataSource;
 
   let userRepository: UserRepository;
   let articleRepository: ArticleRepository;
@@ -69,18 +69,19 @@ describe('User', () => {
     intraAuthRepository = moduleFixture.get(getRepositoryToken(IntraAuth));
     authService = moduleFixture.get(AuthService);
 
+    dataSource = moduleFixture.get(DataSource);
     httpServer = app.getHttpServer();
   });
 
   afterAll(async () => {
-    await getConnection().dropDatabase();
-    await getConnection().close();
+    await dataSource.dropDatabase();
+    await dataSource.destroy();
     await httpServer.close();
   });
 
-  beforeEach(async () => {
-    await clearDB();
-  });
+  // beforeEach(async () => {
+  //   await clearDB();
+  // });
 
   describe('/users/me', () => {
     const intraId = 'chlim';

--- a/apps/api/test/e2e/user.e2e-spec.ts
+++ b/apps/api/test/e2e/user.e2e-spec.ts
@@ -79,9 +79,9 @@ describe('User', () => {
     await httpServer.close();
   });
 
-  // beforeEach(async () => {
-  //   await clearDB();
-  // });
+  beforeEach(async () => {
+    await clearDB(dataSource);
+  });
 
   describe('/users/me', () => {
     const intraId = 'chlim';

--- a/apps/api/test/e2e/utils/utils.ts
+++ b/apps/api/test/e2e/utils/utils.ts
@@ -3,7 +3,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { TestingModule } from '@nestjs/testing';
 import * as cookieParser from 'cookie-parser';
-import { getConnection } from 'typeorm';
+import { DataSource, getConnection } from 'typeorm';
 
 export const clearDB = async () => {
   const entities = getConnection().entityMetadatas;

--- a/apps/api/test/e2e/utils/utils.ts
+++ b/apps/api/test/e2e/utils/utils.ts
@@ -3,12 +3,12 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { TestingModule } from '@nestjs/testing';
 import * as cookieParser from 'cookie-parser';
-import { DataSource, getConnection } from 'typeorm';
+import { DataSource } from 'typeorm';
 
-export const clearDB = async () => {
-  const entities = getConnection().entityMetadatas;
+export const clearDB = async (dataSource: DataSource) => {
+  const entities = dataSource.entityMetadatas;
   for (const entity of entities) {
-    const repository = getConnection().getRepository(entity.name);
+    const repository = dataSource.getRepository(entity.name);
     await repository.query(`TRUNCATE TABLE ${entity.tableName}`);
   }
 };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/schedule": "^1.1.0",
     "@nestjs/swagger": "^5.1.5",
-    "@nestjs/typeorm": "^8.0.2",
+    "@nestjs/typeorm": "10.0.0",
     "@sentry/node": "^6.19.6",
     "adminjs": "^5.7.3",
     "app-root-path": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
     "swagger-ui-express": "^4.3.0",
-    "typeorm": "^0.2.41",
+    "typeorm": "0.3.16",
     "typeorm-naming-strategies": "^2.0.0",
     "winston": "^3.6.0",
     "winston-daily-rotate-file": "^4.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2334,12 +2334,12 @@
     optional "0.1.4"
     tslib "2.3.1"
 
-"@nestjs/typeorm@^8.0.2":
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/@nestjs/typeorm/-/typeorm-8.0.3.tgz#e62feb1f3ec7fa0d1353f774f3f6915594c34a4e"
-  integrity sha512-tf9rTXP6LeFInkwd+tktQhtLRsKp4RRYImprqT8gcHcJDx+xMP1IygnXELOKwF5vo2/mnhrGtBlRQ/iiS6170g==
+"@nestjs/typeorm@10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/typeorm/-/typeorm-10.0.0.tgz#78e20d3413d59dd3dfee03260c904f0f4040b4e1"
+  integrity sha512-WQU4HCDTz4UavsFzvGUKDHqi0MO5K47yFoPXdmh+Z/hCNO7SHCMmV9jLiLukM8n5nKUqJ3jDqiljkWBcZPdCtA==
   dependencies:
-    uuid "8.3.2"
+    uuid "9.0.0"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -9110,7 +9110,7 @@ uuid@8.3.2, uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@^9.0.0:
+uuid@9.0.0, uuid@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,6 +1776,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.21.0":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
+  integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -2491,10 +2498,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sqltools/formatter@^1.2.2":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.3.tgz#1185726610acc37317ddab11c3c7f9066966bd20"
-  integrity sha512-O3uyB/JbkAEMZaP3YqyHH7TMnex7tWyCbCI4EfJdOCoN6HIhqdJBWTM6aCCiWQ/5f5wxjgU735QAIpJbjDvmzg==
+"@sqltools/formatter@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.5.tgz#3abc203c79b8c3e90fd6c156a0c62d5403520e12"
+  integrity sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==
 
 "@styled-system/background@^5.1.2":
   version "5.1.2"
@@ -3036,11 +3043,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/zen-observable@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
-  integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
-
 "@typescript-eslint/eslint-plugin@^5.36.2":
   version "5.37.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.37.0.tgz#5ccdd5d9004120f28fc6e717fb4b5c9bddcfbc04"
@@ -3438,7 +3440,7 @@ ansi-styles@^5.0.0:
 any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
-  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
+  integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
 
 anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.2"
@@ -3452,6 +3454,11 @@ app-root-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-3.0.0.tgz#210b6f43873227e18a4b810a032283311555d5ad"
   integrity sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw==
+
+app-root-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-3.1.0.tgz#5971a2fc12ba170369a7a1ef018c71e6e47c2e86"
+  integrity sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==
 
 append-field@^1.0.0:
   version "1.0.0"
@@ -3469,11 +3476,6 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
-
-argparse@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
-  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 array-flatten@1.1.1:
   version "1.1.1"
@@ -4061,6 +4063,15 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 clone-deep@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
@@ -4183,7 +4194,7 @@ component-emitter@^1.3.0:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 concat-stream@^1.5.2:
   version "1.6.2"
@@ -4420,6 +4431,13 @@ date-fns@^2.0.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
   integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
+date-fns@^2.29.3:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -4586,10 +4604,10 @@ dotenv@16.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"
   integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==
 
-dotenv@^8.2.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
-  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
+dotenv@^16.0.3:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
 
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
@@ -5347,7 +5365,7 @@ fs-monkey@1.0.3:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
 fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
@@ -5424,7 +5442,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -5435,6 +5453,29 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -5679,7 +5720,7 @@ imurmurhash@^0.1.4:
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
   dependencies:
     once "^1.3.0"
     wrappy "1"
@@ -6404,13 +6445,6 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
-
 jsdom@^16.6.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.7.0.tgz#918ae71965424b197c819f8183a754e18977b710"
@@ -6887,7 +6921,7 @@ mini-create-react-context@^0.4.0:
     "@babel/runtime" "^7.12.1"
     tiny-warning "^1.0.3"
 
-minimatch@^3.0.4:
+minimatch@^3.0.4, minimatch@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -6918,10 +6952,10 @@ mkdirp@^0.5.4:
   dependencies:
     minimist "^1.2.6"
 
-mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+mkdirp@^2.1.3:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-2.1.6.tgz#964fbcb12b2d8c5d6fbc62a963ac95a273e2cc19"
+  integrity sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==
 
 moment-timezone@^0.5.x:
   version "0.5.37"
@@ -7154,7 +7188,7 @@ on-headers@~1.0.2:
 once@1.4.0, once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
 
@@ -7357,7 +7391,7 @@ path-exists@^4.0.0:
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
@@ -7914,6 +7948,11 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
@@ -7967,7 +8006,7 @@ regjsparser@^0.8.2:
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
 require-from-string@^2.0.2:
   version "2.0.2"
@@ -8664,7 +8703,7 @@ text-table@^0.2.0:
 thenify-all@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
-  integrity sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=
+  integrity sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==
   dependencies:
     thenify ">= 3.1.0 < 4"
 
@@ -8860,9 +8899,9 @@ tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
+  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
 
 tslib@^2.3.1, tslib@^2.5.0:
   version "2.5.0"
@@ -8950,28 +8989,26 @@ typeorm-naming-strategies@^2.0.0:
   resolved "https://registry.yarnpkg.com/typeorm-naming-strategies/-/typeorm-naming-strategies-2.0.0.tgz#c7c10bc768ddce2592ef9ad4d2dca55fd5fa6ad6"
   integrity sha512-nsJ5jDjhBBEG6olFmxojkO4yrW7hEv38sH7ZXWWx9wnDoo9uaoH/mo2mBYAh/VKgwoFHBLu+CYxGmzXz2GUMcA==
 
-typeorm@^0.2.41:
-  version "0.2.45"
-  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.2.45.tgz#e5bbb3af822dc4646bad96cfa48cd22fa4687cea"
-  integrity sha512-c0rCO8VMJ3ER7JQ73xfk0zDnVv0WDjpsP6Q1m6CVKul7DB9iVdWLRjPzc8v2eaeBuomsbZ2+gTaYr8k1gm3bYA==
+typeorm@0.3.16:
+  version "0.3.16"
+  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.3.16.tgz#a001d77b36cfaaf9ff495e15805dd17883116b7b"
+  integrity sha512-wJ4Qy1oqRKNDdZiBTTaVMqwo/XxC52Q7uNPTjltPgLhvIW173bL6Iad0lhptMOsFlpixFPaUu3PNziaRBwX2Zw==
   dependencies:
-    "@sqltools/formatter" "^1.2.2"
-    app-root-path "^3.0.0"
+    "@sqltools/formatter" "^1.2.5"
+    app-root-path "^3.1.0"
     buffer "^6.0.3"
-    chalk "^4.1.0"
+    chalk "^4.1.2"
     cli-highlight "^2.1.11"
-    debug "^4.3.1"
-    dotenv "^8.2.0"
-    glob "^7.1.6"
-    js-yaml "^4.0.0"
-    mkdirp "^1.0.4"
+    date-fns "^2.29.3"
+    debug "^4.3.4"
+    dotenv "^16.0.3"
+    glob "^8.1.0"
+    mkdirp "^2.1.3"
     reflect-metadata "^0.1.13"
     sha.js "^2.4.11"
-    tslib "^2.1.0"
-    uuid "^8.3.2"
-    xml2js "^0.4.23"
-    yargs "^17.0.1"
-    zen-observable-ts "^1.0.0"
+    tslib "^2.5.0"
+    uuid "^9.0.0"
+    yargs "^17.6.2"
 
 typescript@4.3.5:
   version "4.3.5"
@@ -9072,6 +9109,11 @@ uuid@8.3.2, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.0:
   version "3.0.1"
@@ -9319,7 +9361,7 @@ wrap-ansi@^7.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 write-file-atomic@^3.0.0:
   version "3.0.3"
@@ -9348,19 +9390,6 @@ xml2js@0.4.19:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
-
-xml2js@^0.4.23:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
-  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
-
-xmlbuilder@~11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
-  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlbuilder@~9.0.1:
   version "9.0.7"
@@ -9402,10 +9431,10 @@ yargs-parser@20.x, yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-parser@^21.0.0:
-  version "21.0.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
-  integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^16.0.0, yargs@^16.2.0:
   version "16.2.0"
@@ -9420,33 +9449,20 @@ yargs@^16.0.0, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.0.1:
-  version "17.4.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.4.1.tgz#ebe23284207bb75cee7c408c33e722bfb27b5284"
-  integrity sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==
+yargs@^17.6.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
-    cliui "^7.0.2"
+    cliui "^8.0.1"
     escalade "^3.1.1"
     get-caller-file "^2.0.5"
     require-directory "^2.1.1"
     string-width "^4.2.3"
     y18n "^5.0.5"
-    yargs-parser "^21.0.0"
+    yargs-parser "^21.1.1"
 
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
-
-zen-observable-ts@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz#2d1aa9d79b87058e9b75698b92791c1838551f83"
-  integrity sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==
-  dependencies:
-    "@types/zen-observable" "0.8.3"
-    zen-observable "0.8.15"
-
-zen-observable@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
-  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
## 바뀐점
typeorm 버전을 0.3.16으로 올리면서 수정된 함수 스펙에 맞게 오류를 수정

- custom repository들을 EntityRepository > Injectable 하게 변경
그에 맞게 provider에도 등록

- getConnections가 deprecated 됨에 따라 dataSource를 사용하도록 수정

## 바꾼이유

## 설명
