### PR TITLE
chore: Bump NodeJS from 16 to 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v2
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
       - run: yarn
       - run: yarn typecheck

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ https://www.42world.kr/
 
 ## 버전
 
-- node>=16.13.0
+- node>=18.13.0
 - yarn>=1.22.10
 - docker-compose>=1.29.2
 - docker>=20.10.11

--- a/infra/admin.Dockerfile
+++ b/infra/admin.Dockerfile
@@ -1,5 +1,5 @@
-FROM node:16-alpine3.14
-RUN apk add --no-cache 
+FROM node:18-alpine3.14
+RUN apk add --no-cache
 
 RUN mkdir /home/ft-world
 

--- a/infra/api.Dockerfile
+++ b/infra/api.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.14
+FROM node:18-alpine3.14
 
 WORKDIR /app
 

--- a/infra/batch.Dockerfile
+++ b/infra/batch.Dockerfile
@@ -1,5 +1,5 @@
-FROM node:16-alpine3.14
-RUN apk add --no-cache 
+FROM node:18-alpine3.14
+RUN apk add --no-cache
 
 RUN mkdir /home/ft-world
 


### PR DESCRIPTION
## 바뀐점
close #349 

## 바꾼이유

## 설명
